### PR TITLE
OF-2019 Postpone archiver creation until last possible moment

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MultiUserChatService.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MultiUserChatService.java
@@ -226,7 +226,7 @@ public interface MultiUserChatService extends Component {
      * Sets the time to elapse between logging the room conversations. A <code>TimerTask</code> will
      * be added to a <code>Timer</code> scheduled for repeated fixed-delay execution whose main
      * responsibility is to log queued rooms conversations. The number of queued conversations to
-     * save on each run can be configured. See {@link #setLogMaxBatchSize(int)} (int)}.
+     * save on each run can be configured. See {@link #setLogConversationBatchSize(int)} (int)}.
      *
      * @param timeout the time to elapse between logging the room conversations.
      * @deprecated No longer used in Openfire 4.4.0 and later (replaced with continuous writes to database: see {@link org.jivesoftware.openfire.archive.ArchiveManager}).
@@ -238,7 +238,7 @@ public interface MultiUserChatService extends Component {
      * Returns the time to elapse between logging the room conversations. A <code>TimerTask</code>
      * will be added to a <code>Timer</code> scheduled for repeated fixed-delay execution whose main
      * responsibility is to log queued rooms conversations. The number of queued conversations to
-     * save on each run can be configured. See {@link #getLogMaxBatchSize()} ()}.
+     * save on each run can be configured. See {@link #getLogConversationBatchSize()} ()}.
      *
      * @return the time to elapse between logging the room conversations.
      * @deprecated No longer used in Openfire 4.4.0 and later (replaced with continuous writes to database: see {@link org.jivesoftware.openfire.archive.ArchiveManager}).
@@ -252,14 +252,14 @@ public interface MultiUserChatService extends Component {
      *
      * @param size the number of messages to save to the database on each run of the logging process.
      */
-    void setLogMaxBatchSize(int size);
+    void setLogConversationBatchSize(int size);
 
     /**
      * Returns the number of messages to save to the database on each run of the logging process.
      *
      * @return the number of messages to save to the database on each run of the logging process.
      */
-    int getLogMaxBatchSize();
+    int getLogConversationBatchSize();
 
     /**
      * Sets the maximum time between database writes of log batches.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MultiUserChatService.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MultiUserChatService.java
@@ -17,6 +17,7 @@
 package org.jivesoftware.openfire.muc;
 
 import org.jivesoftware.database.JiveID;
+import org.jivesoftware.openfire.archive.ArchiveManager;
 import org.jivesoftware.openfire.archive.Archiver;
 import org.jivesoftware.openfire.handler.IQHandler;
 import org.jivesoftware.openfire.muc.spi.LocalMUCRoom;
@@ -226,10 +227,10 @@ public interface MultiUserChatService extends Component {
      * Sets the time to elapse between logging the room conversations. A <code>TimerTask</code> will
      * be added to a <code>Timer</code> scheduled for repeated fixed-delay execution whose main
      * responsibility is to log queued rooms conversations. The number of queued conversations to
-     * save on each run can be configured. See {@link #setLogConversationBatchSize(int)} (int)}.
+     * save on each run can be configured. See {@link #setLogConversationBatchSize(int)}.
      *
      * @param timeout the time to elapse between logging the room conversations.
-     * @deprecated No longer used in Openfire 4.4.0 and later (replaced with continuous writes to database: see {@link org.jivesoftware.openfire.archive.ArchiveManager}).
+     * @deprecated No longer used in Openfire 4.4.0 and later (replaced with continuous writes to database: see {@link ArchiveManager}).
      */
     @Deprecated
     default void setLogConversationsTimeout(int timeout) {}
@@ -238,11 +239,12 @@ public interface MultiUserChatService extends Component {
      * Returns the time to elapse between logging the room conversations. A <code>TimerTask</code>
      * will be added to a <code>Timer</code> scheduled for repeated fixed-delay execution whose main
      * responsibility is to log queued rooms conversations. The number of queued conversations to
-     * save on each run can be configured. See {@link #getLogConversationBatchSize()} ()}.
+     * save on each run can be configured. See {@link #getLogConversationBatchSize()}.
      *
      * @return the time to elapse between logging the room conversations.
-     * @deprecated No longer used in Openfire 4.4.0 and later (replaced with continuous writes to database: see {@link org.jivesoftware.openfire.archive.ArchiveManager}).
+     * @deprecated No longer used in Openfire 4.4.0 and later (replaced with continuous writes to database: see {@link ArchiveManager}).
      */
+    @Deprecated
     default int getLogConversationsTimeout() { return 300000; }
 
     /**
@@ -251,45 +253,61 @@ public interface MultiUserChatService extends Component {
      * recommended specifying a big number.
      *
      * @param size the number of messages to save to the database on each run of the logging process.
+     * @deprecated No longer used in Openfire 4.4.0 and later (replaced with continuous writes to database: see {@link ArchiveManager}).
      */
-    void setLogConversationBatchSize(int size);
+    @Deprecated
+    default void setLogConversationBatchSize(int size) {};
 
     /**
      * Returns the number of messages to save to the database on each run of the logging process.
      *
      * @return the number of messages to save to the database on each run of the logging process.
+     * @deprecated No longer used in Openfire 4.4.0 and later (replaced with continuous writes to database: see {@link ArchiveManager}).
      */
-    int getLogConversationBatchSize();
-
-    /**
-     * Sets the maximum time between database writes of log batches.
-     *
-     * @param interval the maximum time between database writes of log batches.
-     */
-    void setLogMaxBatchInterval(Duration interval);
-
-    /**
-     * Returns the maximum time between database writes of log batches.
-     *
-     * @return the maximum time between database writes of log batches.
-     */
-    Duration getLogMaxBatchInterval();
-
-    /**
-     * Sets the maximum time to wait for a new log entry before declaring the batch complete.
-     *
-     * @param period the maximum time to wait for a new log entry before declaring the batch complete.
-     */
-    void setLogBatchGracePeriod(Duration period);
-
-    /**
-     * Returns the maximum time to wait for a new log entry before declaring the batch complete.
-     *
-     * @return the maximum time to wait for a new log entry before declaring the batch complete.
-     */
-    Duration getLogBatchGracePeriod();
+    @Deprecated
+    default int getLogConversationBatchSize() { return 50; };
 
     Archiver<?> getArchiver();
+
+
+    /**
+     * Returns the maximum number of messages to save to the database on each run of the archiving process.
+     * @return the maximum number of messages to save to the database on each run of the archiving process.
+     */
+    default int getLogMaxConversationBatchSize() { return 50; }
+
+    /**
+     * Sets the maximum number of messages to save to the database on each run of the archiving process.
+     * Even though the saving of queued conversations takes place in another thread it is not
+     * recommended specifying a big number.
+     *
+     * @param size the maximum number of messages to save to the database on each run of the archiving process.
+     */
+    default void setLogMaxConversationBatchSize(int size) {}
+
+    /**
+     * Returns the maximum time allowed to elapse between writing archive entries to the database.
+     * @return the maximum time allowed to elapse between writing archive entries to the database.
+     */
+    default Duration getLogMaxBatchInterval() { return Duration.ofSeconds(10l); }
+
+    /**
+     * Sets the maximum time allowed to elapse between writing archive batches to the database.
+     * @param interval the maximum time allowed to elapse between writing archive batches to the database.
+     */
+    default void setLogMaxBatchInterval(Duration interval) {}
+
+    /**
+     * Returns the maximum time to wait for a next incoming entry before writing the batch to the database.
+     * @return the maximum time to wait for a next incoming entry before writing the batch to the database.
+     */
+    default Duration getLogBatchGracePeriod() { return Duration.ofSeconds(1l); }
+
+    /**
+     * Sets the maximum time to wait for a next incoming entry before writing the batch to the database.
+     * @param interval the maximum time to wait for a next incoming entry before writing the batch to the database.
+     */
+    default void setLogBatchGracePeriod(Duration interval) {}
 
     /**
      * Obtain the server-wide default message history settings.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MultiUserChatService.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MultiUserChatService.java
@@ -17,8 +17,6 @@
 package org.jivesoftware.openfire.muc;
 
 import org.jivesoftware.database.JiveID;
-import org.jivesoftware.openfire.archive.ArchiveManager;
-import org.jivesoftware.openfire.archive.Archiver;
 import org.jivesoftware.openfire.handler.IQHandler;
 import org.jivesoftware.openfire.muc.spi.LocalMUCRoom;
 import org.jivesoftware.openfire.muc.spi.MUCPersistenceManager;
@@ -27,6 +25,7 @@ import org.xmpp.component.Component;
 import org.xmpp.packet.JID;
 import org.xmpp.packet.Message;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 
@@ -226,10 +225,10 @@ public interface MultiUserChatService extends Component {
      * Sets the time to elapse between logging the room conversations. A <code>TimerTask</code> will
      * be added to a <code>Timer</code> scheduled for repeated fixed-delay execution whose main
      * responsibility is to log queued rooms conversations. The number of queued conversations to
-     * save on each run can be configured. See {@link #setLogConversationBatchSize(int)}.
+     * save on each run can be configured. See {@link #setLogMaxBatchSize(int)} (int)}.
      *
      * @param timeout the time to elapse between logging the room conversations.
-     * @deprecated No longer used in Openfire 4.4.0 and later (replaced with continuous writes to database: see {@link ArchiveManager}).
+     * @deprecated No longer used in Openfire 4.4.0 and later (replaced with continuous writes to database: see {@link org.jivesoftware.openfire.archive.ArchiveManager}).
      */
     @Deprecated
     default void setLogConversationsTimeout(int timeout) {}
@@ -238,10 +237,10 @@ public interface MultiUserChatService extends Component {
      * Returns the time to elapse between logging the room conversations. A <code>TimerTask</code>
      * will be added to a <code>Timer</code> scheduled for repeated fixed-delay execution whose main
      * responsibility is to log queued rooms conversations. The number of queued conversations to
-     * save on each run can be configured. See {@link #getLogConversationBatchSize()}.
+     * save on each run can be configured. See {@link #getLogMaxBatchSize()} ()}.
      *
      * @return the time to elapse between logging the room conversations.
-     * @deprecated No longer used in Openfire 4.4.0 and later (replaced with continuous writes to database: see {@link ArchiveManager}).
+     * @deprecated No longer used in Openfire 4.4.0 and later (replaced with continuous writes to database: see {@link org.jivesoftware.openfire.archive.ArchiveManager}).
      */
     default int getLogConversationsTimeout() { return 300000; }
 
@@ -251,21 +250,43 @@ public interface MultiUserChatService extends Component {
      * recommended specifying a big number.
      *
      * @param size the number of messages to save to the database on each run of the logging process.
-     * @deprecated No longer used in Openfire 4.4.0 and later (replaced with continuous writes to database: see {@link ArchiveManager}).
      */
-    @Deprecated
-    default void setLogConversationBatchSize(int size) {};
+    void setLogMaxBatchSize(int size);
 
     /**
      * Returns the number of messages to save to the database on each run of the logging process.
      *
      * @return the number of messages to save to the database on each run of the logging process.
-     * @deprecated No longer used in Openfire 4.4.0 and later (replaced with continuous writes to database: see {@link ArchiveManager}).
      */
-    @Deprecated
-    default int getLogConversationBatchSize() { return 50; };
+    int getLogMaxBatchSize();
 
-    Archiver<?> getArchiver();
+    /**
+     * Sets the maximum time between database writes of log batches.
+     *
+     * @param interval the maximum time between database writes of log batches.
+     */
+    void setLogMaxBatchInterval(Duration interval);
+
+    /**
+     * Returns the maximum time between database writes of log batches.
+     *
+     * @return the maximum time between database writes of log batches.
+     */
+    Duration getLogMaxBatchInterval();
+
+    /**
+     * Sets the maximum time to wait for a new log entry before declaring the batch complete.
+     *
+     * @param period the maximum time to wait for a new log entry before declaring the batch complete.
+     */
+    void setLogBatchGracePeriod(Duration period);
+
+    /**
+     * Returns the maximum time to wait for a new log entry before declaring the batch complete.
+     *
+     * @return the maximum time to wait for a new log entry before declaring the batch complete.
+     */
+    Duration getLogBatchGracePeriod();
 
     /**
      * Obtain the server-wide default message history settings.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MultiUserChatService.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MultiUserChatService.java
@@ -17,6 +17,7 @@
 package org.jivesoftware.openfire.muc;
 
 import org.jivesoftware.database.JiveID;
+import org.jivesoftware.openfire.archive.Archiver;
 import org.jivesoftware.openfire.handler.IQHandler;
 import org.jivesoftware.openfire.muc.spi.LocalMUCRoom;
 import org.jivesoftware.openfire.muc.spi.MUCPersistenceManager;
@@ -287,6 +288,8 @@ public interface MultiUserChatService extends Component {
      * @return the maximum time to wait for a new log entry before declaring the batch complete.
      */
     Duration getLogBatchGracePeriod();
+
+    Archiver<?> getArchiver();
 
     /**
      * Obtain the server-wide default message history settings.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -1366,7 +1366,8 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
         return logBatchGracePeriod;
     }
 
-    private Archiver getOrCreateConversationArchiver() {
+    @Override
+    public Archiver getArchiver() {
         if (archiver == null) {
             archiver = new ConversationLogEntryArchiver("MUC Service " + this.getAddress().toString(), logMaxBatchSize, logMaxBatchInterval, logBatchGracePeriod);
             XMPPServer.getInstance().getArchiveManager().add(archiver);
@@ -1530,7 +1531,7 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
     public void logConversation(final MUCRoom room, final Message message, final JID sender) {
         // Only log messages that have a subject or body. Otherwise ignore it.
         if (message.getSubject() != null || message.getBody() != null) {
-            getOrCreateConversationArchiver().archive( new ConversationLogEntry( new Date(), room, message, sender) );
+            getArchiver().archive( new ConversationLogEntry( new Date(), room, message, sender) );
         }
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -1307,7 +1307,7 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
     }
 
     @Override
-    public void setLogMaxBatchSize( int size )
+    public void setLogConversationBatchSize(int size )
     {
         if ( this.logMaxBatchSize == size ) {
             return;
@@ -1321,7 +1321,7 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
     }
 
     @Override
-    public int getLogMaxBatchSize()
+    public int getLogConversationBatchSize()
     {
         return logMaxBatchSize;
     }

--- a/xmppserver/src/main/webapp/muc-tasks.jsp
+++ b/xmppserver/src/main/webapp/muc-tasks.jsp
@@ -115,9 +115,9 @@
         if (batchGrace == null) {
             errors.put("batchGrace","batchGrace");
         }
-        int size = mucService.getArchiver().getMaxWorkQueueSize();
-        Duration batchInterval = mucService.getArchiver().getMaxPurgeInterval();
-        Duration batchGracePeriod = mucService.getArchiver().getGracePeriod();
+        int size = mucService.getLogMaxBatchSize();
+        Duration batchInterval = mucService.getLogMaxBatchInterval();
+        Duration batchGracePeriod = mucService.getLogBatchGracePeriod();
         // Try to obtain an int from the provided strings
         if (errors.size() == 0) {
             try {
@@ -145,9 +145,9 @@
         }
 
         if (errors.size() == 0) {
-            mucService.getArchiver().setMaxWorkQueueSize( size );
-            mucService.getArchiver().setMaxPurgeInterval( batchInterval );
-            mucService.getArchiver().setGracePeriod( batchGracePeriod );
+            mucService.setLogMaxBatchSize( size );
+            mucService.setLogMaxBatchInterval( batchInterval );
+            mucService.setLogBatchGracePeriod( batchGracePeriod );
             // Log the event
             webManager.logEvent("edited muc conversation log settings for service "+mucname, "maxBatchSize = "+maxBatchSize+"\nmaxBatchInterval = "+maxBatchInterval+"\nbatchGrace = "+batchGrace);
             response.sendRedirect("muc-tasks.jsp?logSettingSuccess=true&mucname="+URLEncoder.encode(mucname, "UTF-8"));
@@ -273,7 +273,7 @@
             </td>
             <td width="99%">
                 <input type="number" name="maxbatchsize" size="15" maxlength="50" min="1"
-                       value="<%= mucService.getArchiver().getMaxWorkQueueSize() %>">
+                       value="<%= mucService.getLogMaxBatchSize() %>">
             </td>
         </tr>
         <tr valign="middle">
@@ -282,7 +282,7 @@
             </td>
             <td width="99%">
                 <input type="number" name="maxbatchinterval" size="15" maxlength="50" min="0"
-                 value="<%= mucService.getArchiver().getMaxPurgeInterval().toMillis() %>">
+                 value="<%= mucService.getLogMaxBatchInterval().toMillis() %>">
             </td>
         </tr>
         <tr valign="middle">
@@ -291,7 +291,7 @@
             </td>
             <td width="99%">
                 <input type="number" name="batchgrace" size="15" maxlength="50" min="0"
-                       value="<%= mucService.getArchiver().getGracePeriod().toMillis() %>">
+                       value="<%= mucService.getLogBatchGracePeriod().toMillis() %>">
             </td>
         </tr>
         </table>

--- a/xmppserver/src/main/webapp/muc-tasks.jsp
+++ b/xmppserver/src/main/webapp/muc-tasks.jsp
@@ -115,7 +115,7 @@
         if (batchGrace == null) {
             errors.put("batchGrace","batchGrace");
         }
-        int size = mucService.getLogConversationBatchSize();
+        int size = mucService.getLogMaxConversationBatchSize();
         Duration batchInterval = mucService.getLogMaxBatchInterval();
         Duration batchGracePeriod = mucService.getLogBatchGracePeriod();
         // Try to obtain an int from the provided strings
@@ -145,7 +145,7 @@
         }
 
         if (errors.size() == 0) {
-            mucService.setLogConversationBatchSize( size );
+            mucService.setLogMaxConversationBatchSize( size );
             mucService.setLogMaxBatchInterval( batchInterval );
             mucService.setLogBatchGracePeriod( batchGracePeriod );
             // Log the event

--- a/xmppserver/src/main/webapp/muc-tasks.jsp
+++ b/xmppserver/src/main/webapp/muc-tasks.jsp
@@ -115,7 +115,7 @@
         if (batchGrace == null) {
             errors.put("batchGrace","batchGrace");
         }
-        int size = mucService.getLogMaxBatchSize();
+        int size = mucService.getLogConversationBatchSize();
         Duration batchInterval = mucService.getLogMaxBatchInterval();
         Duration batchGracePeriod = mucService.getLogBatchGracePeriod();
         // Try to obtain an int from the provided strings
@@ -145,7 +145,7 @@
         }
 
         if (errors.size() == 0) {
-            mucService.setLogMaxBatchSize( size );
+            mucService.setLogConversationBatchSize( size );
             mucService.setLogMaxBatchInterval( batchInterval );
             mucService.setLogBatchGracePeriod( batchGracePeriod );
             // Log the event
@@ -273,7 +273,7 @@
             </td>
             <td width="99%">
                 <input type="number" name="maxbatchsize" size="15" maxlength="50" min="1"
-                       value="<%= mucService.getLogMaxBatchSize() %>">
+                       value="<%= mucService.getLogConversationBatchSize() %>">
             </td>
         </tr>
         <tr valign="middle">


### PR DESCRIPTION
Do not create the archiver before its first use. This saves performance overhead for situations where conversation logging is not used.