### PR TITLE
OF-2360 Move plugin version check to a place where it can be reused

### DIFF
--- a/build/debian/openfire.init.d
+++ b/build/debian/openfire.init.d
@@ -46,6 +46,7 @@ test -x $JAVA || exit 1
 
 DAEMON_OPTS="$DAEMON_OPTS -server -DopenfireHome=${DAEMON_DIR} \
  -Dlog4j.configurationFile=${DAEMON_LIB}/log4j2.xml \
+ -Dlog4j2.formatMsgNoLookups=true \
  -Dopenfire.lib.dir=${DAEMON_LIB} -classpath ${DAEMON_LIB}/startup.jar\
  -jar ${DAEMON_LIB}/startup.jar"
 

--- a/distribution/src/bin/extra/openfire-launchd-wrapper.sh
+++ b/distribution/src/bin/extra/openfire-launchd-wrapper.sh
@@ -12,7 +12,7 @@ function shutdown()
 date
 echo "Starting Openfire"
 
-/usr/bin/java -server -jar "$OPENFIRE_HOME/lib/startup.jar" -Dlog4j.configurationFile=$$OPENFIRE_HOME/lib/log4j2.xml -Dopenfire.lib.dir=/usr/local/openfire/lib&
+/usr/bin/java -server -jar "$OPENFIRE_HOME/lib/startup.jar" -Dlog4j.configurationFile=$$OPENFIRE_HOME/lib/log4j2.xml -Dlog4j2.formatMsgNoLookups=true -Dopenfire.lib.dir=/usr/local/openfire/lib&
 
 OPENFIRE_PID=`ps auxww | grep -v wrapper | awk '/openfire/ && !/awk/ {print $2}'`
 

--- a/distribution/src/bin/extra/redhat/openfire
+++ b/distribution/src/bin/extra/redhat/openfire
@@ -98,7 +98,7 @@ else
 	LOCALCLASSPATH="${OPENFIRE_LIB}/startup.jar:${LOCALCLASSPATH}"
 fi
 
-JAVACMD="${JAVACMD} -Dlog4j.configurationFile=${OPENFIRE_LIB}/log4j2.xml"
+JAVACMD="${JAVACMD} -Dlog4j.configurationFile=${OPENFIRE_LIB}/log4j2.xml -Dlog4j2.formatMsgNoLookups=true"
 
 # Export any necessary variables
 export JAVA_HOME JAVACMD

--- a/distribution/src/bin/openfire.bat
+++ b/distribution/src/bin/openfire.bat
@@ -16,7 +16,7 @@ goto end
 :run
 SET debug=
 if "%1" == "-debug" SET debug=-Xdebug -Xint -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8000
-start "Openfire" "%JAVA_HOME%\bin\java" %debug% -server -Djdk.tls.ephemeralDHKeySize=matched -Djsse.SSLEngine.acceptLargeFragments=true -DopenfireHome="%OPENFIRE_HOME%" -Dlog4j.configurationFile="%OPENFIRE_HOME%\lib\log4j2.xml" -Dlog4j.skipJansi=false -Dopenfire.lib.dir="%OPENFIRE_HOME%\lib" -jar "%OPENFIRE_HOME%\lib\startup.jar"
+start "Openfire" "%JAVA_HOME%\bin\java" %debug% -server -Djdk.tls.ephemeralDHKeySize=matched -Djsse.SSLEngine.acceptLargeFragments=true -DopenfireHome="%OPENFIRE_HOME%" -Dlog4j.configurationFile="%OPENFIRE_HOME%\lib\log4j2.xml" -Dlog4j2.formatMsgNoLookups=true -Dlog4j.skipJansi=false -Dopenfire.lib.dir="%OPENFIRE_HOME%\lib" -jar "%OPENFIRE_HOME%\lib\startup.jar"
 goto end
 
 :end

--- a/distribution/src/bin/openfire.sh
+++ b/distribution/src/bin/openfire.sh
@@ -132,7 +132,7 @@ esac
 done
 
 
-JAVACMD="${JAVACMD} -Dlog4j.configurationFile=${OPENFIRE_LIB}/log4j2.xml -Djdk.tls.ephemeralDHKeySize=matched -Djsse.SSLEngine.acceptLargeFragments=true"
+JAVACMD="${JAVACMD} -Dlog4j.configurationFile=${OPENFIRE_LIB}/log4j2.xml -Dlog4j2.formatMsgNoLookups=true -Djdk.tls.ephemeralDHKeySize=matched -Djsse.SSLEngine.acceptLargeFragments=true"
 
 if [ -z "$LOCALCLASSPATH" ] ; then
 	LOCALCLASSPATH=$OPENFIRE_LIB/startup.jar

--- a/distribution/src/bin/openfirectl
+++ b/distribution/src/bin/openfirectl
@@ -107,7 +107,7 @@ else
 	LOCALCLASSPATH="${OPENFIRE_LIB}/startup.jar:${LOCALCLASSPATH}"
 fi
 
-JAVACMD="${JAVACMD} -Dlog4j.configurationFile=${OPENFIRE_LIB}/log4j2.xml"
+JAVACMD="${JAVACMD} -Dlog4j.configurationFile=${OPENFIRE_LIB}/log4j2.xml -Dlog4j2.formatMsgNoLookups=true"
 
 # Export any necessary variables
 export JAVA_HOME JAVACMD

--- a/distribution/src/installer/openfire.install4j
+++ b/distribution/src/installer/openfire.install4j
@@ -59,7 +59,7 @@
       <executable name="${compiler:PRODUCT_NAME}-service" iconSet="true" iconFile="./images/service.ico" executableDir="bin" stderrFile="../logs/stderror.log" redirectStdout="true" stdoutFile="../logs/stdout.log" executableMode="service" singleInstance="true" serviceDescription="${compiler:APP_NAME}" dpiAware="false">
         <versionInfo include="true" fileDescription="${compiler:APP_NAME}" legalCopyright="${compiler:PUBLISHER}" internalName="${compiler:APP_NAME}" />
       </executable>
-      <java mainClass="org.jivesoftware.openfire.starter.ServerStarter" vmParameters="-Djdk.tls.ephemeralDHKeySize=matched -Djsse.SSLEngine.acceptLargeFragments=true -Dlog4j.configurationFile=&quot;${launcher:sys.launcherDirectory}/../lib/log4j2.xml&quot; -Dlog4j.skipJansi=false -DopenfireHome=&quot;${launcher:sys.launcherDirectory}../&quot;" preferredVM="server">
+      <java mainClass="org.jivesoftware.openfire.starter.ServerStarter" vmParameters="-Djdk.tls.ephemeralDHKeySize=matched -Djsse.SSLEngine.acceptLargeFragments=true -Dlog4j.configurationFile=&quot;${launcher:sys.launcherDirectory}/../lib/log4j2.xml&quot; -Dlog4j2.formatMsgNoLookups=true; -Dlog4j.skipJansi=false -DopenfireHome=&quot;${launcher:sys.launcherDirectory}../&quot;" preferredVM="server">
         <classPath>
           <scanDirectory location="lib" failOnError="false" />
         </classPath>
@@ -75,7 +75,7 @@
       <executable name="${compiler:PRODUCT_NAME}" iconSet="true" iconFile="./images/openfire.ico" executableDir="bin" stderrFile="../logs/stderr.log" redirectStdout="true" stdoutFile="../logs/stdout.log" executableMode="gui" singleInstance="true" executionLevel="highestAvailable" dpiAware="false">
         <versionInfo include="true" fileDescription="${compiler:APP_NAME} Launcher" legalCopyright="${compiler:PUBLISHER}" internalName="${compiler:APP_NAME}" />
       </executable>
-      <java mainClass="org.jivesoftware.openfire.launcher.Launcher" vmParameters="-Djdk.tls.ephemeralDHKeySize=matched -Djsse.SSLEngine.acceptLargeFragments=true -Dlog4j.configurationFile=&quot;${launcher:sys.launcherDirectory}/../lib/log4j2.xml&quot; -Dlog4j.skipJansi=false -Dappdir=&quot;${launcher:sys.launcherDirectory}&quot; -DopenfireHome=&quot;${launcher:sys.launcherDirectory}../&quot;">
+      <java mainClass="org.jivesoftware.openfire.launcher.Launcher" vmParameters="-Djdk.tls.ephemeralDHKeySize=matched -Djsse.SSLEngine.acceptLargeFragments=true -Dlog4j.configurationFile=&quot;${launcher:sys.launcherDirectory}/../lib/log4j2.xml&quot; -Dlog4j2.formatMsgNoLookups=true -Dlog4j.skipJansi=false -Dappdir=&quot;${launcher:sys.launcherDirectory}&quot; -DopenfireHome=&quot;${launcher:sys.launcherDirectory}../&quot;">
         <classPath>
           <scanDirectory location="lib" failOnError="false" />
         </classPath>
@@ -91,7 +91,7 @@
       <executable name="${compiler:PRODUCT_NAME}d" iconSet="true" iconFile="./images/openfired.ico" executableDir="bin" redirectStderr="false" executableMode="console" singleInstance="true" executionLevel="highestAvailable" dpiAware="false">
         <versionInfo include="true" fileDescription="${compiler:APP_NAME} Server" legalCopyright="${compiler:PUBLISHER}" internalName="${compiler:APP_NAME}" />
       </executable>
-      <java mainClass="org.jivesoftware.openfire.starter.ServerStarter" vmParameters="-Djdk.tls.ephemeralDHKeySize=matched -Djsse.SSLEngine.acceptLargeFragments=true -Dlog4j.configurationFile=&quot;${launcher:sys.launcherDirectory}/../lib/log4j2.xml&quot; -Dlog4j.skipJansi=false -DopenfireHome=&quot;${launcher:sys.launcherDirectory}../&quot;" preferredVM="server">
+      <java mainClass="org.jivesoftware.openfire.starter.ServerStarter" vmParameters="-Djdk.tls.ephemeralDHKeySize=matched -Djsse.SSLEngine.acceptLargeFragments=true -Dlog4j.configurationFile=&quot;${launcher:sys.launcherDirectory}/../lib/log4j2.xml&quot; -Dlog4j2.formatMsgNoLookups=true -Dlog4j.skipJansi=false -DopenfireHome=&quot;${launcher:sys.launcherDirectory}../&quot;" preferredVM="server">
         <classPath>
           <scanDirectory location="lib" failOnError="false" />
         </classPath>

--- a/distribution/src/installer/openfire.install4j
+++ b/distribution/src/installer/openfire.install4j
@@ -59,7 +59,7 @@
       <executable name="${compiler:PRODUCT_NAME}-service" iconSet="true" iconFile="./images/service.ico" executableDir="bin" stderrFile="../logs/stderror.log" redirectStdout="true" stdoutFile="../logs/stdout.log" executableMode="service" singleInstance="true" serviceDescription="${compiler:APP_NAME}" dpiAware="false">
         <versionInfo include="true" fileDescription="${compiler:APP_NAME}" legalCopyright="${compiler:PUBLISHER}" internalName="${compiler:APP_NAME}" />
       </executable>
-      <java mainClass="org.jivesoftware.openfire.starter.ServerStarter" vmParameters="-Djdk.tls.ephemeralDHKeySize=matched -Djsse.SSLEngine.acceptLargeFragments=true -Dlog4j.configurationFile=&quot;${launcher:sys.launcherDirectory}/../lib/log4j2.xml&quot; -Dlog4j2.formatMsgNoLookups=true; -Dlog4j.skipJansi=false -DopenfireHome=&quot;${launcher:sys.launcherDirectory}../&quot;" preferredVM="server">
+      <java mainClass="org.jivesoftware.openfire.starter.ServerStarter" vmParameters="-Djdk.tls.ephemeralDHKeySize=matched -Djsse.SSLEngine.acceptLargeFragments=true -Dlog4j.configurationFile=&quot;${launcher:sys.launcherDirectory}/../lib/log4j2.xml&quot; -Dlog4j2.formatMsgNoLookups=true -Dlog4j.skipJansi=false -DopenfireHome=&quot;${launcher:sys.launcherDirectory}../&quot;" preferredVM="server">
         <classPath>
           <scanDirectory location="lib" failOnError="false" />
         </classPath>

--- a/distribution/src/resources/log4j2.xml
+++ b/distribution/src/resources/log4j2.xml
@@ -8,7 +8,7 @@
           -->
         <RollingFile name="openfire" fileName="${sys:openfireHome}/logs/openfire.log" filePattern="${sys:openfireHome}/logs/openfire.log-%i">
             <PatternLayout>
-                <Pattern>%d{yyyy.MM.dd HH:mm:ss} %highlight{%-5p} [%t]: %c - %msg%n</Pattern>
+                <Pattern>%d{yyyy.MM.dd HH:mm:ss} %highlight{%-5p} [%t]: %c - %msg{nolookups}%n</Pattern>
             </PatternLayout>
             <Policies>
                 <SizeBasedTriggeringPolicy size="100 MB"/>
@@ -16,7 +16,7 @@
         </RollingFile>
 
         <Console name="console" target="SYSTEM_OUT">
-            <PatternLayout pattern="%msg%n%throwable{0}"/>
+            <PatternLayout pattern="%msg{nolookups}%n%throwable{0}"/>
         </Console>
         
     </Appenders>

--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1772,7 +1772,7 @@ system_property.xmpp.pep.threadpool.keepalive=The number of threads in the threa
 system_property.xmpp.taskengine.threadpool.size.core=The number of threads to keep in the thread pool that is used to execute tasks of Openfire's TaskEngine, even if they are idle.
 system_property.xmpp.taskengine.threadpool.size.max=The maximum number of threads to allow in the thread pool that is used to execute tasks of Openfire's TaskEngine.
 system_property.xmpp.taskengine.threadpool.keepalive=The number of threads in the thread pool that is used to execute tasks of Openfire's TaskEngine is greater than the core, this is the maximum time that excess idle threads will wait for new tasks before terminating.
-
+system_property.xmpp.muc.allowpm.blockall=Toggles whether to block all packets from users or just messages if they do not have permission to send private messages.
 # Server properties Page
 
 server.properties.title=System Properties

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
         <jetty.version>9.4.43.v20210629</jetty.version>
         <standard-taglib.version>1.2.5</standard-taglib.version>
         <mina.version>2.1.3</mina.version>
-        <bouncycastle.version>1.68</bouncycastle.version>
+        <bouncycastle.version>1.70</bouncycastle.version>
         <slf4j.version>1.7.30</slf4j.version>
         <log4j.version>2.17.0</log4j.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
         <mina.version>2.1.3</mina.version>
         <bouncycastle.version>1.68</bouncycastle.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <log4j.version>2.15.0</log4j.version>
+        <log4j.version>2.16.0</log4j.version>
     </properties>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
         <mina.version>2.1.3</mina.version>
         <bouncycastle.version>1.68</bouncycastle.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <log4j.version>2.16.0</log4j.version>
+        <log4j.version>2.17.0</log4j.version>
     </properties>
 
     <profiles>

--- a/xmppserver/changelog.html
+++ b/xmppserver/changelog.html
@@ -162,6 +162,13 @@ hr {
     
     <div id="pageBody">
 
+<h2>(Next version) <span style="font-weight: normal;">(release date)</span></h2>
+
+<h2>Improvement</h2>
+<ul>
+    <li>[<a href="https://igniterealtime.atlassian.net/browse/OF-2360">OF-2360</a>] - Plugin version information accessible through cluster manager</li>
+</ul>
+
 <h2>4.7.0 Beta -- <span style="font-weight: normal;">December 3, 2021</span></h2>
 
 <h2>Bug</h2>

--- a/xmppserver/changelog.html
+++ b/xmppserver/changelog.html
@@ -164,6 +164,11 @@ hr {
 
 <h2>4.7.0 Beta -- <span style="font-weight: normal;">December 3, 2021</span></h2>
 
+<h2>Bug</h2>
+<ul>
+    <li>[<a href="https://igniterealtime.atlassian.net/browse/OF-2244">OF-2244</a>] - Offline presence subscription loses details</li>
+</ul>
+
 <h2>Improvement</h2>
 <ul>
     <li>[<a href="https://igniterealtime.atlassian.net/browse/OF-2349">OF-2349</a>] - Admin console should show \(full\) default value for system property</li>
@@ -179,6 +184,7 @@ hr {
     <li>[<a href="https://igniterealtime.atlassian.net/browse/OF-2276">OF-2276</a>] - Broadcast status codes when privacy settings of a MUC room change</li>
     <li>[<a href="https://igniterealtime.atlassian.net/browse/OF-2275">OF-2275</a>] - When joining a MUC room that has logging enabled, status 170 should be returned.</li>
     <li>[<a href="https://igniterealtime.atlassian.net/browse/OF-2256">OF-2256</a>] - Add CORS headers to websockets</li>
+    <li>[<a href="https://igniterealtime.atlassian.net/browse/OF-2254">OF-2254</a>] - Distinguish between property values that are set to the default value, or are just defaults.</li>
     <li>[<a href="https://igniterealtime.atlassian.net/browse/OF-2252">OF-2252</a>] - Reduce log level for BOSH request that time out</li>
     <li>[<a href="https://igniterealtime.atlassian.net/browse/OF-2251">OF-2251</a>] - Threadpool for BOSH network-IO should be configurable</li>
     <li>[<a href="https://igniterealtime.atlassian.net/browse/OF-2248">OF-2248</a>] - BOSH configuration should go into SystemProperty instances</li>
@@ -768,7 +774,11 @@ hr {
 </li>
 <li>[<a href='https://igniterealtime.atlassian.net/browse/OF-1809'>OF-1809</a>] -         DiscoInfoProvider should allow for more than one &quot;Extended Info&quot; form.
 </li>
+<li>[<a href='https://igniterealtime.atlassian.net/browse/OF-1815'>OF-1815</a>] -         Add MUC search 'muclumbus' support.
+</li>
 <li>[<a href='https://igniterealtime.atlassian.net/browse/OF-1821'>OF-1821</a>] -         Set ldap.pagedResultsSize to 1000 by default when AD integration is used
+</li>
+<li>[<a href='https://igniterealtime.atlassian.net/browse/OF-1832'>OF-1832</a>] -         Show more client session data
 </li>
 <li>[<a href='https://igniterealtime.atlassian.net/browse/OF-1839'>OF-1839</a>] -         XEP-0411: Add or improve support for Bookmarks Conversion
 </li>
@@ -1009,6 +1019,8 @@ hr {
 <li>[<a href='https://igniterealtime.atlassian.net/browse/OF-1685'>OF-1685</a>] -         Group sorting is incorrect
 </li>
 <li>[<a href='https://igniterealtime.atlassian.net/browse/OF-1686'>OF-1686</a>] -         Problems with groups creation
+</li>
+<li>[<a href='https://igniterealtime.atlassian.net/browse/OF-1689'>OF-1689</a>] -         Some messages are not delivered (to all resources)
 </li>
 <li>[<a href='https://igniterealtime.atlassian.net/browse/OF-1691'>OF-1691</a>] -         XEP-0133&#39;s &quot;Delete User&quot; should use jid-multi
 </li>
@@ -1475,6 +1487,8 @@ to <code>true</code> now means that anyone can create PubSub nodes.</p>
 </li>
 <li>[<a href='https://igniterealtime.atlassian.net/browse/OF-1300'>OF-1300</a>] -         Debugger plugin should display remote address.
 </li>
+<li>[<a href='https://igniterealtime.atlassian.net/browse/OF-1337'>OF-1337</a>] -         Privacy list concurrency
+</li>
 <li>[<a href='https://igniterealtime.atlassian.net/browse/OF-1404'>OF-1404</a>] -         Migrate to use Microsoft JDBC Driver
 </li>
 <li>[<a href='https://igniterealtime.atlassian.net/browse/OF-1419'>OF-1419</a>] -         Replace Proxool with Apache Commons DBCP
@@ -1715,6 +1729,8 @@ to <code>true</code> now means that anyone can create PubSub nodes.</p>
 </li>
 <li>[<a href='https://igniterealtime.atlassian.net/browse/OF-1329'>OF-1329</a>] -         Session fixation in admin web console
 </li>
+<li>[<a href='https://igniterealtime.atlassian.net/browse/OF-1331'>OF-1331</a>] -         HTTP console access does not work after HTTPS console access
+</li>
 <li>[<a href='https://igniterealtime.atlassian.net/browse/OF-1335'>OF-1335</a>] -         Forwarded messages rewritten to default namespace over S2S
 </li>
 <li>[<a href='https://igniterealtime.atlassian.net/browse/OF-1356'>OF-1356</a>] -         Add a section about upgrading from x86 to x64 to Upgrade guide (Windows)
@@ -1748,6 +1764,8 @@ to <code>true</code> now means that anyone can create PubSub nodes.</p>
 <li>[<a href='https://igniterealtime.atlassian.net/browse/OF-1431'>OF-1431</a>] -         XMPP Ping without type= set causes a NPE
 </li>
 <li>[<a href='https://igniterealtime.atlassian.net/browse/OF-1436'>OF-1436</a>] -         Sharing BOSH context should not prevent context restart.
+</li>
+<li>[<a href='https://igniterealtime.atlassian.net/browse/OF-1437'>OF-1437</a>] -         Detached sessions sometimes vanish
 </li>
 <li>[<a href='https://igniterealtime.atlassian.net/browse/OF-1441'>OF-1441</a>] -         &lt;scope&gt;test&lt;/scope&gt; Maven dependencies being included in distribution
 </li>

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginMonitor.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginMonitor.java
@@ -479,7 +479,7 @@ public class PluginMonitor implements PropertyEventListener
                 for ( Enumeration e = zipFile.entries(); e.hasMoreElements(); )
                 {
                     JarEntry entry = (JarEntry) e.nextElement();
-                    Path entryFile = dir.resolve( entry.getName() );
+                    Path entryFile = dir.resolve( entry.getName() ); // ignore possibility for zipslip as this is sanitized for if property is enabled lgtm [java/zipslip]
                     // Ignore any manifest.mf entries.
                     if ( entry.getName().toLowerCase().endsWith( "manifest.mf" ) )
                     {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoom.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoom.java
@@ -77,6 +77,12 @@ public class MUCRoom implements GroupEventListener, Externalizable, Result, Cach
         .setChronoUnit(ChronoUnit.MILLIS)
         .build();
 
+    public static SystemProperty<Boolean> ALLOWPM_BLOCKALL = SystemProperty.Builder.ofType( Boolean.class )
+        .setKey("xmpp.muc.allowpm.blockall")
+        .setDefaultValue(false)
+        .setDynamic(true)
+        .build();
+
     /**
      * The service hosting the room.
      */
@@ -1411,7 +1417,7 @@ public class MUCRoom implements GroupEventListener, Externalizable, Result, Cach
      */
     public void sendPrivatePacket(Packet packet, MUCRole senderRole) throws NotFoundException, ForbiddenException {
 
-        if (packet instanceof Message || JiveProperties.getInstance().getBooleanProperty("xmpp.muc.allowpm.blockall", false)){
+        if (packet instanceof Message || ALLOWPM_BLOCKALL.getValue()){
             //If the packet is a message, check that the user has permissions to send
             switch (senderRole.getRole()) { // intended fall-through
                 case none:

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -1119,7 +1119,10 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
 
             // This is for clustering scenarios where one node could already have cleaned up the clustered cache,
             // but the local node still needs to process the 'unavailable' presence of the leaving occupant.
-            preExistingRole = localMUCRoomManager.getLocalRooms().get(roomName).getOccupantByFullJID(packet.getFrom());
+            final MUCRoom localRoom = localMUCRoomManager.getLocalRooms().get(roomName);
+            if (localRoom != null) {
+                preExistingRole = localRoom.getOccupantByFullJID(packet.getFrom());
+            }
 
             if (preExistingRole == null) {
                 Log.debug("Silently ignoring user '{}' leaving a room that it has no role in '{}' (was the room just destroyed)?", packet.getFrom(), roomName);

--- a/xmppserver/src/test/resources/log4j2-test-mvn.xml
+++ b/xmppserver/src/test/resources/log4j2-test-mvn.xml
@@ -4,7 +4,7 @@
     <Appenders>
         <File name="file" fileName="target/surefire-reports/test.log">
             <PatternLayout>
-                <Pattern>%d %-5p %X [%c{1}] - %m%n</Pattern>
+                <Pattern>%d %-5p %X [%c{1}] - %m{nolookups}%n</Pattern>
             </PatternLayout>
         </File>
     </Appenders>

--- a/xmppserver/src/test/resources/log4j2-test.xml
+++ b/xmppserver/src/test/resources/log4j2-test.xml
@@ -3,7 +3,7 @@
 <Configuration>
     <Appenders>
         <Console name="console" target="SYSTEM_OUT">
-            <PatternLayout pattern="%msg%n%throwable{0}"/>
+            <PatternLayout pattern="%msg{nolookups}%n%throwable{0}"/>
         </Console>
     </Appenders>
 


### PR DESCRIPTION
Logic for clusterwide fetching of plugin versions was previously located in a jsp. This PR moves that logic to the cluster manager, so it becomes available for reuse.

Furthermore a new method is introduced that detects version discrepancies of plugins between the local and other nodes. This will be useful for (at least) improving the monitoring plugin.