### PR TITLE
OF-3025: Refactor System Properties UI to remove inline scripts and improve table layout

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/util/ListPager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/ListPager.java
@@ -31,26 +31,36 @@ import org.apache.commons.text.StringEscapeUtils;
 
 /**
  * <p>
- * This class provides an easy way to page through a filterable list of items from a JSP page.
+ * This class provides an easy way to page through a filterable list of items
+ * from a JSP page.
  * </p>
  *
  * <p>
- * It is up to the caller of the class to specify the filter, if required, in the form of a
- * {@link java.util.function.Predicate predicate}. To ensure that search parameters are maintained when paging through
- * the list, it's also necessary to supply a list of input field identifiers that should be included as part of the
- * request when accessing another page. These field identifiers are used to extract the value of the field, and copy it
- * to a hidden form that is used for the actual submission. This means each search criteria has two form fields
- * associated with it - the visible field that the users types in, and in the hidden form that is submitted.
+ * It is up to the caller of the class to specify the filter, if required, in
+ * the form of a
+ * {@link java.util.function.Predicate predicate}. To ensure that search
+ * parameters are maintained when paging through
+ * the list, it's also necessary to supply a list of input field identifiers
+ * that should be included as part of the
+ * request when accessing another page. These field identifiers are used to
+ * extract the value of the field, and copy it
+ * to a hidden form that is used for the actual submission. This means each
+ * search criteria has two form fields
+ * associated with it - the visible field that the users types in, and in the
+ * hidden form that is submitted.
  * </p>
  *
  * <p>
- * The reason for this is that the location of the input fields on the screen may not always be appropriate for a
- * form - for example, if the fields are location within a table, the form must wrap the whole table, which would
+ * The reason for this is that the location of the input fields on the screen
+ * may not always be appropriate for a
+ * form - for example, if the fields are location within a table, the form must
+ * wrap the whole table, which would
  * preclude the use of any other forms within cells in that table.
  * </p>
  *
  * <p>
- * These input fields will also be modified so that pressing Enter/Return when the fields has focus will automatically
+ * These input fields will also be modified so that pressing Enter/Return when
+ * the fields has focus will automatically
  * submit the form.
  * </p>
  *
@@ -64,7 +74,7 @@ public class ListPager<T> {
     private static final String REQUEST_PARAMETER_KEY_SORT_COLUMN_NUMBER = "sortColumnNumber";
     private static final String PAGINATION_FORM_ID = "paginationForm";
     private static final int DEFAULT_PAGE_SIZE = 25;
-    private static final int[] PAGE_SIZES = {25, 50, 100, 1000};
+    private static final int[] PAGE_SIZES = { 25, 50, 100, 1000 };
 
     /**
      * Descending sort (ie 3, 2, 1...).
@@ -88,6 +98,7 @@ public class ListPager<T> {
     private final int sortOrder;
     private final String[] additionalFormFields;
     private final HttpServletRequest request;
+    private boolean inlineJsDisabled = false;
 
     /**
      * Creates a unfiltered list pager.
@@ -95,9 +106,12 @@ public class ListPager<T> {
      * @param request              the request object for the page in question
      * @param response             the response object for the page in question
      * @param items                the list of items to display on the page
-     * @param additionalFormFields 0 or more input field identifiers (<strong>NOT form field names</strong>) to include in requests for other pages
+     * @param additionalFormFields 0 or more input field identifiers (<strong>NOT
+     *                             form field names</strong>) to include in requests
+     *                             for other pages
      */
-    public ListPager(final HttpServletRequest request, final HttpServletResponse response, final List<T> items, final String... additionalFormFields) {
+    public ListPager(final HttpServletRequest request, final HttpServletResponse response, final List<T> items,
+            final String... additionalFormFields) {
         this(request, response, items, item -> true, additionalFormFields);
     }
 
@@ -108,9 +122,12 @@ public class ListPager<T> {
      * @param response             the response object for the page in question
      * @param items                the complete list of items to display on the page
      * @param filter               the filter to apply to the complete list
-     * @param additionalFormFields 0 or more input field identifiers (<strong>NOT form field names</strong>) to include in requests for other pages
+     * @param additionalFormFields 0 or more input field identifiers (<strong>NOT
+     *                             form field names</strong>) to include in requests
+     *                             for other pages
      */
-    public ListPager(final HttpServletRequest request, final HttpServletResponse response, final List<T> items, final Predicate<T> filter, final String... additionalFormFields) {
+    public ListPager(final HttpServletRequest request, final HttpServletResponse response, final List<T> items,
+            final Predicate<T> filter, final String... additionalFormFields) {
         this(request, response, items, filter, 0, false, additionalFormFields);
     }
 
@@ -120,12 +137,18 @@ public class ListPager<T> {
      * @param request              the request object for the page in question
      * @param response             the response object for the page in question
      * @param items                the complete list of items to display on the page
-     * @param sortColumnNumber     the index of the column (0-based) of which values are to be ordered
-     * @param sortDescending       true if the column is to be in descending order, false for ascending order.
+     * @param sortColumnNumber     the index of the column (0-based) of which values
+     *                             are to be ordered
+     * @param sortDescending       true if the column is to be in descending order,
+     *                             false for ascending order.
      * @param filter               the filter to apply to the complete list
-     * @param additionalFormFields 0 or more input field identifiers (<strong>NOT form field names</strong>) to include in requests for other pages
+     * @param additionalFormFields 0 or more input field identifiers (<strong>NOT
+     *                             form field names</strong>) to include in requests
+     *                             for other pages
      */
-    public ListPager(final HttpServletRequest request, final HttpServletResponse response, final List<T> items, final Predicate<T> filter, final int sortColumnNumber, final boolean sortDescending, final String... additionalFormFields) {
+    public ListPager(final HttpServletRequest request, final HttpServletResponse response, final List<T> items,
+            final Predicate<T> filter, final int sortColumnNumber, final boolean sortDescending,
+            final String... additionalFormFields) {
         final HttpSession session = request.getSession();
         final WebManager webManager = new WebManager();
         webManager.init(request, response, session, session.getServletContext());
@@ -136,14 +159,17 @@ public class ListPager<T> {
         this.request = request;
         this.totalItemCount = items.size();
         this.filteredItemCount = filteredItems.size();
-        this.pageSize = bound(ParamUtils.getIntParameter(request, REQUEST_PARAMETER_KEY_PAGE_SIZE, initialPageSize), PAGE_SIZES[PAGE_SIZES.length - 1]);
+        this.pageSize = bound(ParamUtils.getIntParameter(request, REQUEST_PARAMETER_KEY_PAGE_SIZE, initialPageSize),
+                PAGE_SIZES[PAGE_SIZES.length - 1]);
         // Even with no filtered items, we want to display at least one page
-        this.totalPages = Math.max(1, (int) Math.ceil((double)filteredItemCount / (double)pageSize));
+        this.totalPages = Math.max(1, (int) Math.ceil((double) filteredItemCount / (double) pageSize));
         // Bound the current page between 1 and the total number of pages
-        this.currentPage = bound(ParamUtils.getIntParameter(request, REQUEST_PARAMETER_KEY_CURRENT_PAGE, 1), totalPages);
+        this.currentPage = bound(ParamUtils.getIntParameter(request, REQUEST_PARAMETER_KEY_CURRENT_PAGE, 1),
+                totalPages);
         this.firstItemOnPage = filteredItemCount == 0 ? 0 : (currentPage - 1) * pageSize + 1;
         this.lastItemOnPage = filteredItemCount == 0 ? 0 : Math.min(currentPage * pageSize, filteredItemCount);
-        this.itemsOnPage = filteredItemCount == 0 ? Collections.emptyList() : filteredItems.subList(firstItemOnPage - 1, lastItemOnPage);
+        this.itemsOnPage = filteredItemCount == 0 ? Collections.emptyList()
+                : filteredItems.subList(firstItemOnPage - 1, lastItemOnPage);
         this.sortOrder = sortDescending ? DESCENDING : ASCENDING;
         this.sortColumnNumber = sortColumnNumber;
         this.additionalFormFields = additionalFormFields;
@@ -214,7 +240,8 @@ public class ListPager<T> {
     }
 
     /**
-     * @return {@code true} if the supplied filter has restricted the number of items to display, otherwise {@code false}
+     * @return {@code true} if the supplied filter has restricted the number of
+     *         items to display, otherwise {@code false}
      */
     public boolean isFiltered() {
         return totalItemCount != filteredItemCount;
@@ -228,14 +255,24 @@ public class ListPager<T> {
         return sortOrder == DESCENDING;
     }
 
+    public boolean isInlineJsDisabled() {
+        return inlineJsDisabled;
+    }
+
+    public void setInlineJsDisabled(boolean inlineJsDisabled) {
+        this.inlineJsDisabled = inlineJsDisabled;
+    }
+
     /**
      * @return a string that contains HTML for selecting the page size
      */
     public String getPageSizeSelection() {
         final StringBuilder sb = new StringBuilder();
-        sb.append(String.format("<select name='%s' onchange='return setPageSize(this.value);'>", REQUEST_PARAMETER_KEY_PAGE_SIZE));
+        sb.append(String.format("<select name='%s'%s>", REQUEST_PARAMETER_KEY_PAGE_SIZE, inlineJsDisabled ? ""
+                : String.format(" onchange='return setPageSize(this.value);'", REQUEST_PARAMETER_KEY_PAGE_SIZE)));
         for (final int optionSize : PAGE_SIZES) {
-            sb.append(String.format("<option value='%d'%s>%d</option>", optionSize, pageSize == optionSize ? " selected" : "", optionSize));
+            sb.append(String.format("<option value='%d'%s>%d</option>", optionSize,
+                    pageSize == optionSize ? " selected" : "", optionSize));
         }
         sb.append("</select>");
         return sb.toString();
@@ -281,60 +318,70 @@ public class ListPager<T> {
             cssClass = "";
         }
 
-        sb.append(String.format("\n<a href='%s' onclick='return jumpToPage(%d)'%s>%s</a>",
-            String.format("?%s=%d", REQUEST_PARAMETER_KEY_CURRENT_PAGE, pageToLink),
-            pageToLink,
-            cssClass,
-            pageToLink));
+        sb.append(String.format("\n<a href='%s'%s%s>%s</a>",
+                String.format("?%s=%d", REQUEST_PARAMETER_KEY_CURRENT_PAGE, pageToLink),
+                inlineJsDisabled ? "" : String.format(" onclick='return jumpToPage(%d)'", pageToLink),
+                cssClass,
+                pageToLink));
     }
 
     /**
-     * @return the list of hidden fields required to maintain the current list pager state
+     * @return the list of hidden fields required to maintain the current list pager
+     *         state
      */
     public String getHiddenFields() {
         final StringBuilder sb = new StringBuilder("\n")
-            .append(String.format("\t<input type='hidden' name='%s' value='%d'>\n", REQUEST_PARAMETER_KEY_PAGE_SIZE, pageSize))
-            .append(String.format("\t<input type='hidden' name='%s' value='%d'>\n", REQUEST_PARAMETER_KEY_CURRENT_PAGE, currentPage))
-            .append(String.format("\t<input type='hidden' name='%s' value='%d'>\n", REQUEST_PARAMETER_KEY_SORT_ORDER, sortOrder))
-            .append(String.format("\t<input type='hidden' name='%s' value='%d'>\n", REQUEST_PARAMETER_KEY_SORT_COLUMN_NUMBER, sortColumnNumber));
+                .append(String.format("\t<input type='hidden' name='%s' value='%d'>\n", REQUEST_PARAMETER_KEY_PAGE_SIZE,
+                        pageSize))
+                .append(String.format("\t<input type='hidden' name='%s' value='%d'>\n",
+                        REQUEST_PARAMETER_KEY_CURRENT_PAGE, currentPage))
+                .append(String.format("\t<input type='hidden' name='%s' value='%d'>\n",
+                        REQUEST_PARAMETER_KEY_SORT_ORDER, sortOrder))
+                .append(String.format("\t<input type='hidden' name='%s' value='%d'>\n",
+                        REQUEST_PARAMETER_KEY_SORT_COLUMN_NUMBER, sortColumnNumber));
         for (final String additionalFormField : additionalFormFields) {
             final String formFieldValue = ParamUtils.getStringParameter(request, additionalFormField, "");
-            sb.append(String.format("\t<input type='hidden' name='%s' value='%s'%s>\n",
-                additionalFormField,
-                StringEscapeUtils.escapeXml11(formFieldValue),
-                formFieldValue.isEmpty() ? " disabled" : ""));
+            sb.append(String.format(
+                    "<input type='hidden' name='%s' value='%s'>",
+                    additionalFormField,
+                    StringEscapeUtils.escapeXml11(formFieldValue)));
         }
         return sb.toString();
     }
 
     /**
-     * @param request The request to retrieve the values from
-     * @param prefix The first char of the query string - either `?` or `&amp;`
-     * @param additionalFormFields 0 or more form field names to include in requests for other pages
+     * @param request              The request to retrieve the values from
+     * @param prefix               The first char of the query string - either `?`
+     *                             or `&amp;`
+     * @param additionalFormFields 0 or more form field names to include in requests
+     *                             for other pages
      * @return a query string required to maintain the current list pager state
      */
-    public static String getQueryString(final HttpServletRequest request, final char prefix, final String... additionalFormFields) {
+    public static String getQueryString(final HttpServletRequest request, final char prefix,
+            final String... additionalFormFields) {
         final StringBuilder sb = new StringBuilder();
         char conjunction = prefix;
         final int currentPage = ParamUtils.getIntParameter(request, REQUEST_PARAMETER_KEY_CURRENT_PAGE, 1);
         if (currentPage > 1) {
             sb.append(conjunction)
-                .append(String.format("%s=%d", REQUEST_PARAMETER_KEY_CURRENT_PAGE, currentPage));
+                    .append(String.format("%s=%d", REQUEST_PARAMETER_KEY_CURRENT_PAGE, currentPage));
             conjunction = '&';
         }
-        final int pageSize = bound(ParamUtils.getIntParameter(request, REQUEST_PARAMETER_KEY_PAGE_SIZE, DEFAULT_PAGE_SIZE), PAGE_SIZES[PAGE_SIZES.length - 1]);
+        final int pageSize = bound(
+                ParamUtils.getIntParameter(request, REQUEST_PARAMETER_KEY_PAGE_SIZE, DEFAULT_PAGE_SIZE),
+                PAGE_SIZES[PAGE_SIZES.length - 1]);
         if (pageSize != DEFAULT_PAGE_SIZE) {
             sb.append(conjunction)
-                .append(String.format("%s=%d", REQUEST_PARAMETER_KEY_PAGE_SIZE, pageSize));
+                    .append(String.format("%s=%d", REQUEST_PARAMETER_KEY_PAGE_SIZE, pageSize));
             conjunction = '&';
         }
         for (final String additionalFormField : additionalFormFields) {
             final String formFieldValue = ParamUtils.getStringParameter(request, additionalFormField, "").trim();
-            if(!formFieldValue.isEmpty()) {
+            if (!formFieldValue.isEmpty()) {
                 String encodedValue;
                 encodedValue = URLEncoder.encode(formFieldValue, StandardCharsets.UTF_8);
                 sb.append(conjunction)
-                    .append(String.format("%s=%s", additionalFormField, encodedValue));
+                        .append(String.format("%s=%s", additionalFormField, encodedValue));
                 conjunction = '&';
             }
         }
@@ -342,21 +389,26 @@ public class ListPager<T> {
     }
 
     /**
-     * @return a string with an HTML form containing hidden fields, used for navigating between pages
+     * @return a string with an HTML form containing hidden fields, used for
+     *         navigating between pages
      */
     public String getJumpToPageForm() {
         return "\n" +
-            String.format("<form id='%s'>\n", PAGINATION_FORM_ID) +
-            getHiddenFields() +
-            "</form>\n";
+                String.format("<form id='%s'>\n", PAGINATION_FORM_ID) +
+                getHiddenFields() +
+                "</form>\n";
     }
 
     /**
-     * @return a string containing JavaScript that helps with navigation between pages
+     * @return a string containing JavaScript that helps with navigation between
+     *         pages
      */
     public String getPageFunctions() {
+        if (inlineJsDisabled) {
+            return "";
+        }
         final StringBuilder sb = new StringBuilder("\n")
-            .append("\tvar additionalFormFields = [");
+                .append("\tvar additionalFormFields = [");
         // The list of additional form fields
         for (final String additionalFormField : additionalFormFields) {
             if (!additionalFormField.equals(additionalFormFields[0])) {
@@ -367,84 +419,96 @@ public class ListPager<T> {
         sb.append("];\n\n");
 
         sb.append("\tfunction jumpToPage(pageNumber) {\n")
-            // Changes the current page number, and submits the form
-            .append(String.format("\t\tvar formObject = document.getElementById('%s');\n", PAGINATION_FORM_ID))
-            .append(String.format("\t\tformObject.%s.value = pageNumber;\n", REQUEST_PARAMETER_KEY_CURRENT_PAGE))
-            .append("\t\tsubmitForm();\n")
-            .append("\t\treturn false;\n")
-            .append("\t}\n")
-            .append("\n");
+                // Changes the current page number, and submits the form
+                .append(String.format("\t\tvar formObject = document.getElementById('%s');\n", PAGINATION_FORM_ID))
+                .append(String.format("\t\tformObject.%s.value = pageNumber;\n", REQUEST_PARAMETER_KEY_CURRENT_PAGE))
+                .append("\t\tsubmitForm();\n")
+                .append("\t\treturn false;\n")
+                .append("\t}\n")
+                .append("\n");
 
         sb.append("\tfunction setPageSize(pageSize) {\n")
-            // Changes the current page size, and submits the form
-            .append(String.format("\t\tvar formObject = document.getElementById('%s');\n", PAGINATION_FORM_ID))
-            .append(String.format("\t\tformObject.%s.value = pageSize;\n", REQUEST_PARAMETER_KEY_PAGE_SIZE))
-            .append("\t\tsubmitForm();\n")
-            .append("\t\treturn false;\n")
-            .append("\t}\n")
-            .append("\n");
+                // Changes the current page size, and submits the form
+                .append(String.format("\t\tvar formObject = document.getElementById('%s');\n", PAGINATION_FORM_ID))
+                .append(String.format("\t\tformObject.%s.value = pageSize;\n", REQUEST_PARAMETER_KEY_PAGE_SIZE))
+                .append("\t\tsubmitForm();\n")
+                .append("\t\treturn false;\n")
+                .append("\t}\n")
+                .append("\n");
 
         sb.append("\tfunction toggleColumnOrder(sortColumnNumber) {\n")
-            // Orders based on a particular column, reversing the order if that column was already ordered on.
-            .append(String.format("\t\tvar formObject = document.getElementById('%s');\n", PAGINATION_FORM_ID))
-            .append(String.format("\t\tvar previousSortColumnNumber = formObject.%s.value || '0';\n", REQUEST_PARAMETER_KEY_SORT_COLUMN_NUMBER))
-            .append(String.format("\t\tvar previousSortOrder = formObject.%s.value || '1';\n", REQUEST_PARAMETER_KEY_SORT_ORDER))
-            .append(String.format("\t\tformObject.%s.value = sortColumnNumber;\n", REQUEST_PARAMETER_KEY_SORT_COLUMN_NUMBER))
-            .append(String.format("\t\tformObject.%s.value = parseInt(previousSortColumnNumber) === sortColumnNumber ? 1-previousSortOrder : 1;\n", REQUEST_PARAMETER_KEY_SORT_ORDER))
-            .append("\t\tsubmitForm();\n")
-            .append("\t\treturn false;\n")
-            .append("\t}\n")
-            .append("\n");
+                // Orders based on a particular column, reversing the order if that column was
+                // already ordered on.
+                .append(String.format("\t\tvar formObject = document.getElementById('%s');\n", PAGINATION_FORM_ID))
+                .append(String.format("\t\tvar previousSortColumnNumber = formObject.%s.value || '0';\n",
+                        REQUEST_PARAMETER_KEY_SORT_COLUMN_NUMBER))
+                .append(String.format("\t\tvar previousSortOrder = formObject.%s.value || '1';\n",
+                        REQUEST_PARAMETER_KEY_SORT_ORDER))
+                .append(String.format("\t\tformObject.%s.value = sortColumnNumber;\n",
+                        REQUEST_PARAMETER_KEY_SORT_COLUMN_NUMBER))
+                .append(String.format(
+                        "\t\tformObject.%s.value = parseInt(previousSortColumnNumber) === sortColumnNumber ? 1-previousSortOrder : 1;\n",
+                        REQUEST_PARAMETER_KEY_SORT_ORDER))
+                .append("\t\tsubmitForm();\n")
+                .append("\t\treturn false;\n")
+                .append("\t}\n")
+                .append("\n");
 
         sb.append("\tfunction submitForm() {\n")
-            // Extracts any of the additional form field values, and adds them to the form before submitting it
-            .append(String.format("\t\tvar formObject = document.getElementById('%s');\n", PAGINATION_FORM_ID))
-            .append(String.format("\t\tfor(var i = 0; i < %d; i++) {\n", additionalFormFields.length))
-            .append("\t\t\tvar field = document.getElementById(additionalFormFields[i]);\n")
-            .append("\t\t\tif (field !== null) {\n")
-            .append("\t\t\t\tvar formField = formObject[additionalFormFields[i]];\n")
-            .append("\t\t\t\tif (typeof field !== 'object' || field.value === '') {\n")
-            .append("\t\t\t\t\tformField.disabled = true;\n")
-            .append("\t\t\t\t} else {\n")
-            .append("\t\t\t\t\tformField.disabled = false;\n")
-            .append("\t\t\t\t\tformField.value = field.value;\n")
-            .append("\t\t\t\t}\n")
-            .append("\t\t\t}\n")
-            .append("\t\t}\n")
-            .append("\t\t\n")
-            .append("\t\tif (formObject['").append(REQUEST_PARAMETER_KEY_PAGE_SIZE).append("'].value === '").append(pageSize).append("') formObject['").append(REQUEST_PARAMETER_KEY_PAGE_SIZE).append("'].disabled=true;\n")
-            .append("\t\tif (formObject['").append(REQUEST_PARAMETER_KEY_CURRENT_PAGE).append("'].value === '1') formObject['").append(REQUEST_PARAMETER_KEY_CURRENT_PAGE).append("'].disabled=true;\n")
-            .append("\t\t\n")
-            .append("\t\tformObject.submit();\n")
-            .append("\t\treturn false;\n")
-            .append("\t}\n")
-            .append("\n");
+                // Extracts any of the additional form field values, and adds them to the form
+                // before submitting it
+                .append(String.format("\t\tvar formObject = document.getElementById('%s');\n", PAGINATION_FORM_ID))
+                .append(String.format("\t\tfor(var i = 0; i < %d; i++) {\n", additionalFormFields.length))
+                .append("\t\t\tvar field = document.getElementById(additionalFormFields[i]);\n")
+                .append("\t\t\tif (field !== null) {\n")
+                .append("\t\t\t\tvar formField = formObject[additionalFormFields[i]];\n")
+                .append("\t\t\t\tif (typeof field !== 'object' || field.value === '') {\n")
+                .append("\t\t\t\t\tformField.disabled = true;\n")
+                .append("\t\t\t\t} else {\n")
+                .append("\t\t\t\t\tformField.disabled = false;\n")
+                .append("\t\t\t\t\tformField.value = field.value;\n")
+                .append("\t\t\t\t}\n")
+                .append("\t\t\t}\n")
+                .append("\t\t}\n")
+                .append("\t\t\n")
+                .append("\t\tif (formObject['").append(REQUEST_PARAMETER_KEY_PAGE_SIZE).append("'].value === '")
+                .append(pageSize).append("') formObject['").append(REQUEST_PARAMETER_KEY_PAGE_SIZE)
+                .append("'].disabled=true;\n")
+                .append("\t\tif (formObject['").append(REQUEST_PARAMETER_KEY_CURRENT_PAGE)
+                .append("'].value === '1') formObject['").append(REQUEST_PARAMETER_KEY_CURRENT_PAGE)
+                .append("'].disabled=true;\n")
+                .append("\t\t\n")
+                .append("\t\tformObject.submit();\n")
+                .append("\t\treturn false;\n")
+                .append("\t}\n")
+                .append("\n");
 
-        // Add mechanisms to auto-submit the form when hitting enter (two mechanisms for different browsers)
+        // Add mechanisms to auto-submit the form when hitting enter (two mechanisms for
+        // different browsers)
         sb.append("\tfunction inputFieldOnKeyDownEventListener(e) {\n")
-            .append("\t\tif (e.keyCode === 13) {\n")
-            .append("\t\t\tsubmitForm();\n")
-            .append("\t\t\treturn false;\n")
-            .append("\t\t}\n")
-            .append("\t}\n")
-            .append("\n");
+                .append("\t\tif (e.keyCode === 13) {\n")
+                .append("\t\t\tsubmitForm();\n")
+                .append("\t\t\treturn false;\n")
+                .append("\t\t}\n")
+                .append("\t}\n")
+                .append("\n");
 
         sb.append("\tfunction inputFieldOnInputEventListener() {\n")
-            .append("\t\tif (this.value === '') {\n")
-            .append("\t\t\tsubmitFilterForm();\n")
-            .append("\t\t\treturn false;\n")
-            .append("\t\t}\n")
-            .append("\t};\n")
-            .append("\n");
+                .append("\t\tif (this.value === '') {\n")
+                .append("\t\t\tsubmitFilterForm();\n")
+                .append("\t\t\treturn false;\n")
+                .append("\t\t}\n")
+                .append("\t};\n")
+                .append("\n");
 
         // Finally, bind the functions to the fields
         sb.append(String.format("\tfor(var i = 0; i < %d; i++) {\n", additionalFormFields.length))
-            .append("\t\tvar field = document.getElementById(additionalFormFields[i]);\n")
-            .append("\t\tif (field !== null && typeof field === 'object') {\n")
-            .append("\t\t\tfield.onkeydown = inputFieldOnKeyDownEventListener;\n")
-            .append("\t\t\tfield.addEventListener('input', inputFieldOnInputEventListener);\n")
-            .append("\t\t}\n")
-            .append("\t}\n");
+                .append("\t\tvar field = document.getElementById(additionalFormFields[i]);\n")
+                .append("\t\tif (field !== null && typeof field === 'object') {\n")
+                .append("\t\t\tfield.onkeydown = inputFieldOnKeyDownEventListener;\n")
+                .append("\t\t\tfield.addEventListener('input', inputFieldOnInputEventListener);\n")
+                .append("\t\t}\n")
+                .append("\t}\n");
 
         return sb.toString();
     }

--- a/xmppserver/src/main/webapp/js/list-pager.js
+++ b/xmppserver/src/main/webapp/js/list-pager.js
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2025 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Common logic for ListPager navigation.
+ */
+const ListPager = (function() {
+    const PAGINATION_FORM_ID = 'paginationForm';
+    const REQUEST_PARAMETER_KEY_PAGE_SIZE = 'listPagerPageSize';
+    const REQUEST_PARAMETER_KEY_CURRENT_PAGE = 'listPagerCurrentPage';
+
+    function getForm() {
+        return document.getElementById(PAGINATION_FORM_ID);
+    }
+
+    function getAdditionalFormFields() {
+        const form = getForm();
+        if (!form) return [];
+        const fieldsJson = form.getAttribute('data-additional-form-fields');
+        try {
+            return fieldsJson ? JSON.parse(fieldsJson) : [];
+        } catch (e) {
+            console.error("Error parsing additionalFormFields", e);
+            return [];
+        }
+    }
+
+    function jumpToPage(pageNumber) {
+        const formObject = getForm();
+        if (formObject) {
+            formObject[REQUEST_PARAMETER_KEY_CURRENT_PAGE].value = pageNumber;
+            submitForm();
+        }
+        return false;
+    }
+
+    function setPageSize(pageSize) {
+        const formObject = getForm();
+        if (formObject) {
+            formObject[REQUEST_PARAMETER_KEY_PAGE_SIZE].value = pageSize;
+            submitForm();
+        }
+        return false;
+    }
+
+    function submitForm() {
+        const formObject = getForm();
+        if (!formObject) return false;
+
+        const additionalFormFields = getAdditionalFormFields();
+        for (let i = 0; i < additionalFormFields.length; i++) {
+            const field = document.getElementById(additionalFormFields[i]);
+            if (field !== null) {
+                const formField = formObject[additionalFormFields[i]];
+                if (!formField) {
+                    console.warn("Hidden form field missing for:", additionalFormFields[i]);
+                    continue;
+                }
+                if (typeof field !== 'object' || field.value === '') {
+                    formField.disabled = true;
+                } else {
+                    formField.disabled = false;
+                    formField.value = field.value;
+                }
+            }
+        }
+
+        // Disable unchanged page size or default page number to keep URL clean
+        const initialPageSize = formObject.getAttribute('data-page-size');
+        if (formObject[REQUEST_PARAMETER_KEY_PAGE_SIZE].value === initialPageSize) {
+            formObject[REQUEST_PARAMETER_KEY_PAGE_SIZE].disabled = true;
+        }
+        if (formObject[REQUEST_PARAMETER_KEY_CURRENT_PAGE].value === '1') {
+            formObject[REQUEST_PARAMETER_KEY_CURRENT_PAGE].disabled = true;
+        }
+
+        formObject.submit();
+        return false;
+    }
+
+    function inputFieldOnKeyDownEventListener(e) {
+        if (e.keyCode === 13) {
+            submitForm();
+            return false;
+        }
+    }
+
+    function inputFieldOnInputEventListener() {
+        if (this.value === '') {
+            submitForm();
+            return false;
+        }
+    }
+
+    function init() {
+        const form = getForm();
+        if (!form) return;
+
+        const additionalFormFields = getAdditionalFormFields();
+        for (let i = 0; i < additionalFormFields.length; i++) {
+            const field = document.getElementById(additionalFormFields[i]);
+            if (field !== null && typeof field === 'object') {
+                field.onkeydown = inputFieldOnKeyDownEventListener;
+                field.addEventListener('input', inputFieldOnInputEventListener);
+            }
+        }
+
+        // Event delegation for pagination links
+        document.addEventListener('click', function(e) {
+            const anchor = e.target.closest('a');
+            if (anchor && !anchor.onclick && anchor.href.includes(REQUEST_PARAMETER_KEY_CURRENT_PAGE)) {
+                try {
+                    const url = new URL(anchor.href, window.location.origin);
+                    const page = url.searchParams.get(REQUEST_PARAMETER_KEY_CURRENT_PAGE);
+                    if (page) {
+                        e.preventDefault();
+                        jumpToPage(page);
+                    }
+                } catch (err) {
+                    // Ignore URL parsing errors for relative links if URL constructor fails
+                }
+            }
+        });
+
+        // Event delegation for page size selector
+        document.addEventListener('change', function(e) {
+            if (e.target.name === REQUEST_PARAMETER_KEY_PAGE_SIZE && !e.target.onchange) {
+                setPageSize(e.target.value);
+            }
+        });
+    }
+
+    return {
+        init: init,
+        jumpToPage: jumpToPage,
+        setPageSize: setPageSize,
+        submitForm: submitForm
+    };
+})();
+
+document.addEventListener('DOMContentLoaded', ListPager.init);

--- a/xmppserver/src/main/webapp/js/system-properties.js
+++ b/xmppserver/src/main/webapp/js/system-properties.js
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2025 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+(function() {
+    function getKey(imgObject) {
+        // Find the first span in the first cell (nameColumn) of this row
+        const row = imgObject.closest('tr');
+        if (row) {
+            const span = row.querySelector('.nameColumn span');
+            if (span) {
+                return span.textContent;
+            }
+        }
+        return "";
+    }
+
+    function doEdit(imgObject, hidden, encrypted, nullValue) {
+        document.getElementById("editPropertyName").value = getKey(imgObject);
+        const valueField = document.getElementById("editPropertyValue");
+        
+        if (encrypted || hidden || nullValue) {
+            valueField.value = "";
+        } else {
+            const row = imgObject.closest('tr');
+            if (row) {
+                const valueSpan = row.querySelector('.valueColumn span');
+                if (valueSpan) {
+                    valueField.value = valueSpan.textContent;
+                }
+            }
+        }
+
+        const defaultValueField = document.getElementById("defaultPropertyValue");
+        const row = imgObject.closest('tr');
+        if (row) {
+            // Default value is in the 3rd column (index 2)
+            const defaultValueCell = row.querySelectorAll('.valueColumn')[1];
+            if (defaultValueCell) {
+                defaultValueField.innerText = defaultValueCell.textContent;
+            }
+        }
+
+        document.getElementById(encrypted ? "editPropertyEncryptTrue" : "editPropertyEncryptFalse").checked = true;
+        document.getElementById("newPropertyTitle").style.display = "none";
+        document.getElementById("editPropertyTitle").style.display = "";
+        valueField.focus();
+        // Modern approach to move cursor to start/end
+        valueField.setSelectionRange(0, 0);
+        window.scrollTo(0, document.body.scrollHeight);
+    }
+
+    function doEncrypt(imgObject) {
+        const confirmMessage = document.getElementById('actionForm').getAttribute('data-encrypt-confirm');
+        if (confirm(confirmMessage)) {
+            submitActionForm("encrypt", getKey(imgObject));
+        }
+    }
+
+    function doDelete(imgObject) {
+        const confirmMessage = document.getElementById('actionForm').getAttribute('data-delete-confirm');
+        if (confirm(confirmMessage)) {
+            submitActionForm("delete", getKey(imgObject));
+        }
+    }
+
+    function submitEditForm(save) {
+        const action = save ? "save" : "cancel";
+        const key = document.getElementById("editPropertyName").value;
+        if (key.trim() === "") {
+            return;
+        }
+        if (save) {
+            const value = document.getElementById("editPropertyValue").value;
+            const encrypt = document.getElementById("editPropertyEncryptTrue").checked;
+            submitActionForm(action, key, value, encrypt);
+        } else {
+            submitActionForm(action, key);
+        }
+    }
+
+    function submitActionForm(action, key, value, encrypt) {
+        const form = document.getElementById("actionForm");
+        form["action"].value = action;
+        form["key"].value = key;
+        if (typeof value !== "undefined") {
+            form["value"].value = value;
+            form["value"].disabled = false;
+        } else {
+            form["value"].disabled = true;
+        }
+        if (typeof encrypt !== "undefined") {
+            form["encrypt"].value = encrypt;
+            form["encrypt"].disabled = false;
+        } else {
+            form["encrypt"].disabled = true;
+        }
+        form.submit();
+    }
+
+    document.addEventListener('DOMContentLoaded', function() {
+        // Action icons in the table
+        document.addEventListener('click', function(e) {
+            const target = e.target.closest('.clickable');
+            if (!target) return;
+
+            if (target.getAttribute('src').indexOf('edit-16x16.gif') > -1) {
+                const hidden = target.getAttribute('data-hidden') === 'true';
+                const encrypted = target.getAttribute('data-encrypted') === 'true';
+                const nullValue = target.getAttribute('data-null-value') === 'true';
+                doEdit(target, hidden, encrypted, nullValue);
+            } else if (target.getAttribute('src').indexOf('add-16x16.gif') > -1) {
+                doEncrypt(target);
+            } else if (target.getAttribute('src').indexOf('delete-16x16.gif') > -1) {
+                doDelete(target);
+            } else if (target.getAttribute('alt') === 'Search') {
+                if (typeof ListPager !== 'undefined') {
+                    ListPager.submitForm();
+                }
+            }
+        });
+
+        // Save/Cancel buttons
+        const saveBtn = document.getElementById('savePropertyBtn');
+        if (saveBtn) {
+            saveBtn.addEventListener('click', () => submitEditForm(true));
+        }
+        const cancelBtn = document.getElementById('cancelPropertyBtn');
+        if (cancelBtn) {
+            cancelBtn.addEventListener('click', () => submitEditForm(false));
+        }
+
+        // Global keydown for Enter on search inputs
+        const searchInputs = ["searchName", "searchValue", "searchDescription"];
+        searchInputs.forEach(id => {
+            const input = document.getElementById(id);
+            if (input) {
+                input.addEventListener('keydown', function(e) {
+                    if (e.keyCode === 13) {
+                        if (typeof ListPager !== 'undefined') {
+                            ListPager.submitForm();
+                        }
+                    }
+                });
+            }
+        });
+    });
+})();

--- a/xmppserver/src/main/webapp/system-properties.jsp
+++ b/xmppserver/src/main/webapp/system-properties.jsp
@@ -30,19 +30,20 @@
     <title><fmt:message key="server.properties.title"/></title>
     <meta name="pageID" content="server-props"/>
     <meta name="helpPage" content="manage_system_properties.html"/>
+    <script src="js/list-pager.js"></script>
+    <script src="js/system-properties.js"></script>
     <style>
         .nameColumn {
-            text-overflow: ellipsis;
-            overflow: hidden;
-            white-space: nowrap;
-            max-width: 200px;
+            overflow-wrap: break-word;
+            word-wrap: break-word;
+            max-width: 250px;
         }
 
         .valueColumn {
-            text-overflow: ellipsis;
-            overflow: hidden;
-            white-space: nowrap;
             max-width: 250px;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
 
         .hidden {
@@ -107,31 +108,29 @@
             <td nowrap>
                 <input type="search"
                        id="searchName"
-                       size="40"
+                       size="20"
                        value="<c:out value="${search.name}"/>"/>
                 <img src="images/search-16x16.png"
                      width="16" height="16"
                      class="clickable"
                      alt="Search" title="Search"
                      style="vertical-align: middle;"
-                     onclick="submitForm();"
                 >
             </td>
             <td nowrap>
                 <input type="search"
                        id="searchValue"
-                       size="40"
+                       size="20"
                        value="<c:out value="${search.value}"/>"/>
                 <img src="images/search-16x16.png"
                      width="16" height="16"
                      class="clickable"
                      alt="Search" title="Search"
                      style="vertical-align: middle;"
-                     onclick="submitForm();"
                 >
             </td>
             <td nowrap>
-                <select id="searchDefaultValue" onchange="submitForm();">
+                <select id="searchDefaultValue">
                     <option value="" <c:if test="${search.defaultValue == ''}">selected</c:if>><fmt:message key="server.properties.search_all"/></option>
                     <option value="unchanged" <c:if test="${search.defaultValue == 'unchanged'}">selected</c:if>><fmt:message key="server.properties.default.search_unchanged"/></option>
                     <option value="changed" <c:if test="${search.defaultValue == 'changed'}">selected</c:if>><fmt:message key="server.properties.default.search_changed"/></option>
@@ -139,7 +138,7 @@
                 </select>
             </td>
             <td nowrap>
-                <select id="searchPlugin" onchange="submitForm();">
+                <select id="searchPlugin">
                     <option value="" <c:if test="${search.plugin == ''}">selected</c:if>><fmt:message key="server.properties.search_all"/></option>
                     <option value="none" <c:if test="${search.plugin == 'none'}">selected</c:if>><fmt:message key="server.properties.search_none"/></option>
                     <c:forEach var="plugin" items="${plugins}">
@@ -157,11 +156,10 @@
                      class="clickable"
                      alt="Search" title="Search"
                      style="vertical-align: middle;"
-                     onclick="submitForm();"
                 >
             </td>
             <td nowrap style="text-align: center">
-                <select id="searchDynamic" onchange="submitForm();">
+                <select id="searchDynamic">
                     <option value="" <c:if test="${search.dynamic == ''}">selected</c:if>><fmt:message key="server.properties.search_all"/></option>
                     <option value="true" <c:if test="${search.dynamic == 'true'}">selected</c:if>><fmt:message key="server.properties.dynamic.search.true"/></option>
                     <option value="false" <c:if test="${search.dynamic == 'false'}">selected</c:if>><fmt:message key="server.properties.dynamic.search.false"/></option>
@@ -170,7 +168,7 @@
                 </select>
             </td>
             <td nowrap style="text-align: center">
-                <select id="searchSetByUser" onchange="submitForm();">
+                <select id="searchSetByUser">
                     <option value="" <c:if test="${search.setByUser == ''}">selected</c:if>><fmt:message key="server.properties.search_all"/></option>
                     <option value="true" <c:if test="${search.setByUser == 'true'}">selected</c:if>><fmt:message key="server.properties.setbyuser.search.true"/></option>
                     <option value="false" <c:if test="${search.setByUser == 'false'}">selected</c:if>><fmt:message key="server.properties.setbyuser.search.false"/></option>
@@ -208,7 +206,7 @@
                             <span class="hidden">none</span>
                         </c:when>
                         <c:otherwise>
-                            <span><c:out value="${property.valueAsSaved}"/></span>
+                            <span title="<c:out value="${property.valueAsSaved}"/>"><c:out value="${property.valueAsSaved}"/></span>
                             <c:if test="${property.valueAsSaved != property.displayValue}">
                                 (<c:out value="${property.displayValue}"/>)
                             </c:if>
@@ -224,7 +222,7 @@
                             <span class="hidden">none</span>
                         </c:when>
                         <c:otherwise>
-                            <c:out value="${property.defaultDisplayValue}"/>
+                            <span title="<c:out value="${property.defaultDisplayValue}"/>"><c:out value="${property.defaultDisplayValue}"/></span>
                         </c:otherwise>
                     </c:choose>
                 </td>
@@ -259,7 +257,9 @@
                     <img class="clickable"
                         src="images/edit-16x16.gif"
                         width="16" height="16"
-                        onclick="doEdit(this, <c:out value='${property.hidden}'/>, <c:out value='${property.encrypted}'/>, <c:out value='${property.displayValue == null}'/>)"
+                        data-hidden="<c:out value='${property.hidden}'/>"
+                        data-encrypted="<c:out value='${property.encrypted}'/>"
+                        data-null-value="<c:out value='${property.displayValue == null}'/>"
                         alt="<fmt:message key="server.properties.alt_edit"/>">
                 </td>
                 <td style="text-align:center">
@@ -272,7 +272,6 @@
                             <img class="clickable"
                                 src="images/add-16x16.gif"
                                 width="16" height="16"
-                                onclick="doEncrypt(this);"
                                 alt="<fmt:message key="server.properties.alt_encrypt"/>">
                         </c:otherwise>
                     </c:choose>
@@ -281,7 +280,6 @@
                     <img class="clickable"
                         src="images/delete-16x16.gif"
                         width="16" height="16"
-                        onclick="doDelete(this);"
                         alt="<fmt:message key="server.properties.alt_delete"/>">
                 </td>
             </tr>
@@ -290,7 +288,11 @@
     </table>
 </div>
 <p><fmt:message key="global.pages"/>: [ ${listPager.pageLinks} ]</p>
-${listPager.jumpToPageForm}
+<form id='paginationForm'
+      data-additional-form-fields='["searchName", "searchValue", "searchDefaultValue", "searchPlugin", "searchDescription", "searchDynamic", "searchSetByUser"]'
+      data-page-size='${listPager.pageSize}'>
+    ${listPager.hiddenFields}
+</form>
 
 <div class="jive-table">
     <table>
@@ -356,8 +358,8 @@ ${listPager.jumpToPageForm}
         <tfoot>
         <tr>
             <td colspan="2">
-                <input type="button" value="<fmt:message key="global.save_property" />" onclick="submitEditForm(true);">
-                <input type="button" value="<fmt:message key="global.cancel" />" onclick="submitEditForm(false);">
+                <input type="button" id="savePropertyBtn" value="<fmt:message key="global.save_property" />">
+                <input type="button" id="cancelPropertyBtn" value="<fmt:message key="global.cancel" />">
             </td>
         </tr>
         </tfoot>
@@ -365,86 +367,17 @@ ${listPager.jumpToPageForm}
 </div>
 
 
-<form method="post" id="actionForm">
-    <%=listPager.getHiddenFields()%>
+<form method="post" id="actionForm"
+      data-encrypt-confirm="<fmt:message key="server.properties.encrypt_confirm"/>"
+      data-delete-confirm="<fmt:message key="server.properties.delete_confirm"/>">
+    ${listPager.hiddenFields}
     <input type="hidden" name="csrf" value="<c:out value='${csrf}'/>">
     <input type="hidden" name="action">
     <input type="hidden" name="key">
     <input type="hidden" name="value">
     <input type="hidden" name="encrypt">
 </form>
-
-<script>
-    ${listPager.pageFunctions}
-
-    function getKey(imgObject) {
-        return imgObject.parentNode.parentNode.childNodes[1].childNodes[1].textContent;
-    }
-
-    function doEdit(imgObject, hidden, encrypted, nullValue) {
-        document.getElementById("editPropertyName").value = getKey(imgObject);
-        let valueField = document.getElementById("editPropertyValue");
-        if (encrypted || hidden || nullValue) {
-            valueField.value = "";
-        } else {
-            valueField.value = imgObject.parentNode.parentNode.childNodes[3].childNodes[1].textContent;
-        }
-
-        let defaultValueField = document.getElementById("defaultPropertyValue");
-        defaultValueField.innerText = imgObject.parentNode.parentNode.childNodes[5].childNodes[0].textContent.trim();
-
-        document.getElementById(encrypted ? "editPropertyEncryptTrue" : "editPropertyEncryptFalse").checked = true;
-        document.getElementById("newPropertyTitle").style.display = "none";
-        document.getElementById("editPropertyTitle").style.display = "";
-        valueField.focus();
-        valueField.selectionEnd = 0;
-        window.scrollTo(0, document.body.scrollHeight);
-    }
-
-    function doEncrypt(imgObject) {
-        if (confirm('<fmt:message key="server.properties.encrypt_confirm"/>')) {
-            submitActionForm("encrypt", getKey(imgObject));
-        }
-    }
-
-    function doDelete(imgObject) {
-        if (confirm('<fmt:message key="server.properties.delete_confirm"/>')) {
-            submitActionForm("delete", getKey(imgObject));
-        }
-    }
-
-    function submitEditForm(save) {
-        let action = save ? "save" : "cancel";
-        let key = document.getElementById("editPropertyName").value;
-        if (key.trim() === "") {
-            <%-- There's no need to submit the form --%>
-            return;
-        }
-        if (save) {
-            let value = document.getElementById("editPropertyValue").value;
-            let encrypt = document.getElementById("editPropertyEncryptTrue").checked;
-            submitActionForm(action, key, value, encrypt);
-        } else {
-            submitActionForm(action, key);
-        }
-    }
-
-    function submitActionForm(action, key, value, encrypt) {
-        let form = document.getElementById("actionForm");
-        form["action"].value = action;
-        form["key"].value = key;
-        if(typeof value !== "undefined") {
-            form["value"].value = value;
-        } else {
-            form["value"].disabled = true;
-        }
-        if(typeof encrypt !== "undefined") {
-            form["encrypt"].value = encrypt;
-        } else {
-            form["encrypt"].disabled = true;
-        }
-        form.submit();
-    }
-</script>
+<%-- Refactor; disable inline JS in ListPager and use list-pager.js --%>
+<% listPager.setInlineJsDisabled(true); %>
 </body>
 </html>


### PR DESCRIPTION
This PR refactors the System Properties administrative page to ensure better Content Security Policy (CSP) compliance and fixes several UI rendering issues.

**Changes included:**
* **Removed Inline JavaScript:** Extracted inline JS from `system-properties.jsp` into external files (`system-properties.js` and `list-pager.js`) to comply with strict CSP directives without requiring `'unsafe-inline'`.
* **Fixed Data Layout Bugs:** Corrected an issue where invisible whitespaces and line-breaks broke the edit/delete buttons, and moved dialog confirmation properties away from the `<body>` tag so they are no longer stripped out by SiteMesh.
* **Improved Table UX & CSS:** Added `overflow-wrap` to property names to prevent horizontal scrolling on small screens. For excessively long property values (like complex CSP headers), added `text-overflow: ellipsis` to restrict the height to a single line, combined with `title` attributes so users can view the full un-truncated values on hover.
