### PR TITLE
Refactor SCRAM-SHA-1 implementation into an abstract base class

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/ScramSaslServer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/ScramSaslServer.java
@@ -15,44 +15,700 @@
  */
 package org.jivesoftware.openfire.sasl;
 
+import com.google.common.annotations.VisibleForTesting;
+import org.jivesoftware.openfire.net.SASLAuthentication;
+import org.jivesoftware.openfire.session.LocalSession;
+import org.jivesoftware.openfire.user.UserNotFoundException;
+import org.jivesoftware.util.channelbinding.ChannelBindingProviderManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.security.sasl.Sasl;
 import javax.security.sasl.SaslException;
 import javax.security.sasl.SaslServer;
-import java.util.Arrays;
+import javax.xml.bind.DatatypeConverter;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
+/**
+ * Abstract base class representing a SCRAM SASL (Simple Authentication and Security Layer) server.
+ *
+ * This class provides utility methods and abstract definitions to implement specific SCRAM-based SASL mechanisms, such
+ * as SCRAM-SHA-1 or SCRAM-SHA-256. It is responsible for managing cryptographically-secure operations, retrieving user
+ * authentication data, and protecting against various security vulnerabilities such as timing attacks and user
+ * enumeration.
+ *
+ * Subclasses of this abstract class must implement methods to handle storage and retrieval of user credentials, as well
+ * as cryptographic computations specific to the chosen SCRAM mechanism.
+ */
 public abstract class ScramSaslServer implements SaslServer
 {
+    private static final Logger Log = LoggerFactory.getLogger(ScramSaslServer.class);
+
+    public static final String PROPNAME_CHANNELBINDINGTYPE = "channelbindingtype";
+
+    private static final Pattern CLIENT_FIRST_MESSAGE = Pattern.compile("^(([pny])=?([^,]*),([^,]*),)(m?=?[^,]*,?n=([^,]*),r=([^,]*),?.*)$");
+    private static final Pattern CLIENT_FINAL_MESSAGE = Pattern.compile("(c=([^,]*),r=([^,]*)),p=(.*)$");
+
+    /**
+     * Indicates whether the current mechanism is operating in "plus" mode. "Plus" mode refers to a variant that
+     * provides channel binding support for SCRAM authentication.
+     */
+    protected final boolean isPlusMechanism;
+
+    /**
+     * A thread-safe, cryptographically strong random number generator used for various security-related computations
+     * within the SASL server mechanisms.
+     *
+     * This field is initialized with {@link SecureRandom}, a platform-provided implementation that uses entropy to
+     * generate random numbers suitable for cryptographic purposes. The randomness it provides is critical to ensuring
+     * the strength of operations such as key generation, nonces, and other cryptographic primitives.
+     */
+    protected final SecureRandom random = new SecureRandom();
+
+    /**
+     * Provides access to server-supported channel binding implementations.
+     *
+     * This manager is used to determine whether a channel binding type requested by a client is supported by the
+     * server, and to validate channel binding requirements for SCRAM -PLUS mechanisms.
+     */
+    private final ChannelBindingProviderManager channelBindingProviderManager;
+
+    /**
+     * The set of SASL mechanism names currently supported by the server.
+     *
+     * This is primarily used to detect SCRAM channel binding downgrade attacks as described in RFC 5802 section 6.
+     */
+    private final Set<String> serverSupportedSaslMechanismNames;
+
+    /**
+     * SASL properties associated with this authentication exchange.
+     *
+     * These properties can provide contextual information required during authentication, such as the active session or
+     * transport-layer information used for channel binding.
+     */
+    private final Map<String, ?> props;
+
+    /**
+     * The combined SCRAM nonce used during the authentication exchange.
+     *
+     * This value consists of the client-provided nonce concatenated with a server-generated nonce contribution, as
+     * required by RFC 5802.
+     */
+    private String nonce;
+
+    /**
+     * The server-first-message sent to the client during SCRAM authentication.
+     *
+     * This value is retained for later inclusion in the SCRAM authentication message used to verify proofs and generate
+     * signatures.
+     */
+    private String serverFirstMessage;
+
+    /**
+     * The client-first-message-bare value extracted from the client's initial SCRAM message.
+     *
+     * This excludes the GS2 header and is retained for inclusion in the SCRAM authentication message used during proof
+     * verification.
+     */
+    private String clientFirstMessageBare;
+
+    /**
+     * The expected decoded channel binding payload for the client-final-message.
+     *
+     * For SCRAM -PLUS mechanisms, this consists of the concatenation of the raw GS2 header and transport-layer channel
+     * binding data. For non-PLUS mechanisms, this contains only the GS2 header.
+     *
+     * The value is compared against the decoded {@code c=} attribute supplied by the client in the final SCRAM message.
+     */
+    private byte[] expectedChannelBindingPayloadInFinalClientMessage;
+
+    /**
+     * The GS2 channel binding type requested by the client.
+     *
+     * This corresponds to the channel binding name conveyed in the GS2 header (for example {@code tls-exporter}) and is
+     * only applicable for SCRAM -PLUS mechanisms.
+     */
+    private String gs2CbindName;
+
+    /**
+     * The authentication identity supplied by the client.
+     *
+     * This value is extracted from the SCRAM client-first-message and represents the username being authenticated.
+     */
+    private String username;
+
+    /**
+     * Represents the states of the SASL authentication process within the {@code ScramSaslServer}.
+     *
+     * This enum is intended to manage the progression through the various phases of the SCRAM authentication mechanism.
+     * It transitions from the initial state to completion as the authentication exchange progresses.
+     */
+    protected enum State {
+        INITIAL,
+        IN_PROGRESS,
+        COMPLETE;
+    }
+
+    /**
+     * Represents the current state of the SASL authentication process within the {@code ScramSaslServer}.
+     */
+    protected State state = State.INITIAL;
+
+    public ScramSaslServer(final boolean isPlusMechanism, final Map<String, ?> props)
+    {
+        this.isPlusMechanism = isPlusMechanism;
+        this.props = props;
+        this.channelBindingProviderManager = ChannelBindingProviderManager.getInstance();
+        this.serverSupportedSaslMechanismNames = SASLAuthentication.getSupportedMechanisms();
+    }
+
+    /**
+     * Constructor for testing purposes.
+     */
+    @VisibleForTesting
+    ScramSaslServer(final boolean isPlusMechanism, final Map<String, ?> props, final ChannelBindingProviderManager channelBindingProviderManager, final Set<String> serverSupportedSaslMechanismNames)
+    {
+        this.isPlusMechanism = isPlusMechanism;
+        this.props = props;
+        this.channelBindingProviderManager = channelBindingProviderManager;
+        this.serverSupportedSaslMechanismNames = serverSupportedSaslMechanismNames;
+    }
+
+    /**
+     * Retrieve the iteration count for a given username.
+     *
+     * This method can return a default value if a user-specific iteration count is not available.
+     *
+     * @param username the username for which the iteration count is to be retrieved
+     * @return the iteration count
+     */
+    protected abstract int getIterations(final String username);
+
+    /**
+     * Retrieve the salt from the database for a given username.
+     *
+     * @param username the username for which the salt is to be retrieved
+     * @return the salt
+     * @throws UserNotFoundException if the user is not found
+     */
+    protected abstract byte[] getSalt(String username) throws UserNotFoundException;
+
+    /**
+     * Retrieve the server key from the database for a given username.
+     *
+     * @param username the username for which the server key is to be retrieved
+     * @return the server key as a byte array, or null if the key is not found
+     * @throws UserNotFoundException if the user is not found
+     */
+    protected abstract byte[] getServerKey(String username) throws UserNotFoundException;
+
+    /**
+     * Retrieve the stored key from the database for a given username.
+     *
+     * @param username the username for which the stored key is to be retrieved
+     * @return the stored key as a byte array, or null if the key is not found
+     * @throws UserNotFoundException if the user is not found
+     */
+    protected abstract byte[] getStoredKey(String username) throws UserNotFoundException;
+
+    protected abstract byte[] digest(final byte[] value) throws NoSuchAlgorithmException;
+
+    /**
+     * Computes the HMAC (Hash-based Message Authentication Code) for the given input key and value.
+     *
+     * @param key   the secret key to be used for HMAC computation
+     * @param value the input string for which the HMAC is to be calculated
+     * @return a byte array representing the computed HMAC
+     * @throws SaslException if an error occurs during the HMAC computation
+     */
+    protected abstract byte[] computeHmac(byte[] key, String value) throws SaslException;
+
+    /**
+     * Retrieves the length, in bytes, of the derived key used in the SASL mechanism.
+     *
+     * @return the derived key length in bytes
+     */
+    protected abstract int getDerivedKeyLengthBytes();
+
+    /**
+     * Returns the expected length of SCRAM salt values, in bytes.
+     *
+     * This value is used when generating deterministic fake salts for non-existent users to ensure that generated salts
+     * are indistinguishable in size from real salts.
+     *
+     * @return the salt length in bytes
+     */
+    protected abstract int getSaltLength();
+
+    /**
+     * Retrieves a server-side secret used for authentication when the provided user does not exist in the system. This
+     * method is typically used to guard against timing attacks by returning consistent responses for both existing and
+     * non-existent users.
+     *
+     * @return a server-side secret for non-existent users, represented as a string
+     */
+    protected abstract String getServerSecretForNonExistentUsers();
+
+    /**
+     * Retrieves the SCRAM salt for a user or generates a deterministic fake salt when the user does not exist or no
+     * salt is available.
+     *
+     * Returning a fake salt helps protect against user enumeration attacks by ensuring that authentication processing
+     * for non-existent users resembles processing for existing users.
+     *
+     * @param username the username for which to obtain a salt
+     * @return a real or fake salt value
+     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-3258">OF-3258: Guard against user enumeration in ScramSha1SaslServer</a>
+     */
+    protected final byte[] getOrFakeSalt(final String username)
+    {
+        try
+        {
+            final byte[] salt = getSalt(username);
+            if (salt != null) {
+                return salt;
+            }
+        }
+        catch (UserNotFoundException e)
+        {
+            Log.trace("User '{}' not found. Returning fake salt.", username, e);
+            // fall through
+        }
+        return generateFakeSalt(username);
+    }
+
+    /**
+     * Generate a fake salt to guard against user enumeration attacks (see OF-3258).
+     *
+     * The returned salt is a deterministic but cryptographically unpredictable value derived from the username and a
+     * server-side secret. The returned value is always exactly {@link #getSaltLength()} bytes long.
+     *
+     * @param username The username for which to generate a fake salt
+     * @return a fake salt of length {@link #getSaltLength()}.
+     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-3258">OF-3258: Guard against user enumeration in ScramSha1SaslServer</a>
+     */
+    private byte[] generateFakeSalt(String username)
+    {
+        final int length = getSaltLength();
+
+        try
+        {
+            final byte[] key = getServerSecretForNonExistentUsers().getBytes(StandardCharsets.UTF_8);
+            final byte[] result = new byte[length];
+
+            int offset = 0;
+            int counter = 0;
+
+            while (offset < length)
+            {
+                // Domain separation + counter to expand output deterministically
+                final byte[] block = computeHmac(key, "fake-salt-for-" + username + ":" + counter);
+                final int toCopy = Math.min(block.length, length - offset);
+                System.arraycopy(block, 0, result, offset, toCopy);
+
+                offset += toCopy;
+                counter++;
+            }
+
+            return result;
+        }
+        catch (SaslException e)
+        {
+            // Give up trying to be deterministic. Return a random salt.
+            final byte[] salt = new byte[length];
+            random.nextBytes(salt);
+            return salt;
+        }
+    }
+
     /**
      * Retrieve the server key from the database for a given username, but returns a fake key if none is found.
      *
-     * Returning a fake key helps guard against timing attacks: instead of short-circuiting the operation,
-     * a fake key is generated to ensure consistent response times and prevent potential timing attacks.
+     * Returning a fake key helps guard against timing attacks: instead of short-circuiting the operation, a fake key is
+     * generated to ensure consistent response times and prevent potential timing attacks.
+     *
+     * @param username the username for which to obtain a server key
+     * @return a real or fake server key
      *
      * @see <a href="https://igniterealtime.atlassian.net/browse/OF-3257">OF-3257: Guard against timing attacks in ScramSha1SaslServer</a>
      */
-    abstract byte[] getOrFakeServerKey(String username);
+    protected final byte[] getOrFakeServerKey(String username)
+    {
+        try {
+            final byte[] key = getServerKey(username);
+            if (key != null) {
+                return key;
+            }
+        } catch (UserNotFoundException e) {
+            Log.trace("User '{}' not found. Returning fake server key.", username, e);
+            // fall through
+        }
+        return generateFakeKey("server-key-" + username);
+    }
 
     /**
      * Retrieve the stored key from the database for a given username, but returns a fake key if none is found.
      *
-     * Returning a fake key helps guard against timing attacks: instead of short-circuiting the operation,
-     * a fake key is generated to ensure consistent response times and prevent potential timing attacks.
+     * Returning a fake key helps guard against timing attacks: instead of short-circuiting the operation, a fake key is
+     * generated to ensure consistent response times and prevent potential timing attacks.
      *
+     * @param username the username for which to obtain a stored key
+     * @return a real or fake stored key
      * @see <a href="https://igniterealtime.atlassian.net/browse/OF-3257">OF-3257: Guard against timing attacks in ScramSha1SaslServer</a>
      */
-    abstract byte[] getOrFakeStoredKey(final String username);
+    protected final byte[] getOrFakeStoredKey(final String username)
+    {
+        try {
+            final byte[] key = getStoredKey(username);
+            if (key != null) {
+                return key;
+            }
+        } catch (UserNotFoundException e) {
+            Log.trace("User '{}' not found. Returning fake stored key.", username, e);
+            // fall through
+        }
+        return generateFakeKey("stored-key-" + username);
+    }
 
     /**
-     * Retrieve the salt for a given username.
+     * Generate a fake key to guard against timing attacks.
      *
-     * When a salt does not currently exist for an existing user, but a password is set, that value is used to create
-     * and persist a new salt for that user.
-     *
-     * Returns a username-specific salt if the user doesn't exist to mimic an invalid password. This also guards against
-     * user enumeration attacks.
-     *
-     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-3258">OF-3258: Guard against user enumeration in ScramSha1SaslServer</a>
+     * @param input a string input for which to generate a fake key
+     * @return a fake key
+     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-3257">OF-3257: Guard against timing attacks in ScramSha1SaslServer</a>
      */
-    abstract byte[] getOrCreateSalt(final String username);
+    protected final byte[] generateFakeKey(String input)
+    {
+        try {
+            return computeHmac(
+                getServerSecretForNonExistentUsers().getBytes(StandardCharsets.UTF_8),
+                input
+            );
+        } catch (SaslException e) {
+            byte[] fallback = new byte[getDerivedKeyLengthBytes()];
+            random.nextBytes(fallback);
+            return fallback;
+        }
+    }
+
+    /**
+     * Evaluates the response data and generates a challenge.
+     *
+     * If a response is received from the client during the authentication process, this method is called to prepare an
+     * appropriate next challenge to submit to the client. The challenge is null if the authentication has succeeded,
+     * and no more challenge data is to be sent to the client. It is non-null if the authentication must be continued
+     * by sending a challenge to the client, or if the authentication has succeeded but challenge data needs to be
+     * processed by the client. {@code isComplete()} should be called  after each call to {@code evaluateResponse()},
+     * to determine if any further response is needed from the client.
+     *
+     * @param response The non-null (but possibly empty) response sent by the client.
+     * @return The possibly null challenge to send to the client. It is null if the authentication has succeeded and there is no more challenge data to be sent to the client.
+     * @exception SaslException If an error occurred while processing the response or generating a challenge.
+     */
+    @Override
+    public byte[] evaluateResponse(final byte[] response) throws SaslException {
+        try {
+            byte[] challenge;
+            switch (state)
+            {
+                case INITIAL:
+                    challenge = generateServerFirstMessage(response);
+                    state = State.IN_PROGRESS;
+                    break;
+                case IN_PROGRESS:
+                    challenge = generateServerFinalMessage(response);
+                    state = State.COMPLETE;
+                    break;
+                case COMPLETE:
+                    if (response == null || response.length == 0)
+                    {
+                        challenge = new byte[0];
+                        break;
+                    }
+                    throw new SaslException("Unexpected response after authentication completed");
+                default:
+                    throw new SaslException("No response expected in state " + state);
+
+            }
+            return challenge;
+        } catch (RuntimeException ex) {
+            throw new SaslException("Unexpected exception while evaluating SASL response.", ex);
+        }
+    }
+
+    /**
+     * First response returns:
+     *   - the nonce (client nonce appended with our own random UUID)
+     *   - the salt
+     *   - the number of iterations
+     */
+    private byte[] generateServerFirstMessage(final byte[] response) throws SaslException {
+        String clientFirstMessage = new String(response, StandardCharsets.UTF_8);
+        Matcher m = CLIENT_FIRST_MESSAGE.matcher(clientFirstMessage);
+        if (!m.matches()) {
+            throw new SaslException("Invalid first client message");
+        }
+        final byte[] gs2_header = extractRawGS2Header(response); // Using raw header to prevent any normalization issues that might pop up when using something like: gs2Header.getBytes(StandardCharsets.UTF_8);
+//        String gs2Header = m.group(1);
+        String gs2CbindFlag = m.group(2);
+        gs2CbindName = m.group(3);
+//        String authzId = m.group(4);
+        clientFirstMessageBare = m.group(5);
+        username = m.group(6);
+        String clientNonce = m.group(7);
+
+        if (username == null || username.isEmpty()) {
+            throw new SaslException("Invalid first client message: Username cannot be empty");
+        }
+        if (clientNonce == null || clientNonce.isEmpty()) {
+            throw new SaslException("Invalid first client message: Client nonce cannot be empty");
+        }
+
+        // https://www.rfc-editor.org/rfc/rfc5802.html#section-6: If the flag is set to "y" and the server supports
+        // channel binding, the server MUST fail authentication. This is because if the client sets the channel binding
+        // flag to "y", then the client must have believed that the server did not support channel binding -- if the
+        // server did in fact support channel binding, then this is an indication that there has been a downgrade attack
+        // (e.g., an attacker changed the server's mechanism list to exclude the -PLUS suffixed SCRAM mechanism name(s)).
+        final boolean clientSupportsChannelBindingButThinksServerDoesNot = "y".equals(gs2CbindFlag);
+        final boolean serverSupportsChannelBinding = serverSupportedSaslMechanismNames.contains(isPlusMechanism ? getMechanismName() : getMechanismName() + "-PLUS");
+        if (clientSupportsChannelBindingButThinksServerDoesNot && serverSupportsChannelBinding) {
+            throw new SaslException("Client supports channel binding, but thinks the server does not (while it does). Rejecting authentication to prevent downgrade attack.");
+        }
+
+        final boolean clientRequiresChannelBinding = "p".equals(gs2CbindFlag);
+        if (clientRequiresChannelBinding && !isPlusMechanism) {
+            throw new SaslException("Client requires channel binding, but is not using a -PLUS mechanism. Rejecting authentication.");
+        }
+
+        if (isPlusMechanism)
+        {
+            if (!clientRequiresChannelBinding) {
+                throw new SaslException("Channel binding required for -PLUS. Rejecting authentication.");
+            }
+
+            if (!serverSupportsChannelBinding) {
+                throw new SaslException("Client requires channel binding, but server does not support channel binding. Rejecting authentication.");
+            }
+
+            // https://www.rfc-editor.org/rfc/rfc5802.html#section-6: If the channel binding flag was "p" and the server
+            // does not support the indicated channel binding type, then the server MUST fail authentication.
+            if (gs2CbindName == null || gs2CbindName.isEmpty() || !channelBindingProviderManager.supportsChannelBinding(gs2CbindName)) {
+                throw new SaslException("Client requires channel binding, but server does not support the indicated channel binding type '" + gs2CbindName + "'. Rejecting authentication.");
+            }
+
+            // Prepare channel binding data.
+            final LocalSession session = (LocalSession) props.get(LocalSession.class.getCanonicalName());
+            if (session == null || session.getConnection() == null) {
+                throw new SaslException("Local session not found in properties. Rejecting authentication.");
+            }
+            final Optional<byte[]> channelBindingData = session.getConnection().getChannelBindingData(gs2CbindName);
+            if (channelBindingData.isEmpty()) {
+                Log.debug("Unable to retrieve channel binding data for '{}'. Rejecting authentication.", gs2CbindName);
+                throw new SaslException("Unable to retrieve channel binding data for '" + gs2CbindName + "'. Rejecting authentication.");
+            }
+
+            // In the final client message, we expect to find a combination of the gs2 header and channel binding data.
+            final byte[] cb_data = channelBindingData.get();
+            expectedChannelBindingPayloadInFinalClientMessage = new byte[gs2_header.length + cb_data.length];
+            System.arraycopy(gs2_header, 0, expectedChannelBindingPayloadInFinalClientMessage, 0, gs2_header.length);
+            System.arraycopy(cb_data,    0, expectedChannelBindingPayloadInFinalClientMessage, gs2_header.length, cb_data.length);
+        } else {
+            // If this is _not_ a -PLUS mechanism, we still need to verify the channel binding payload in the final client message.
+            // In that case, it should not have trailing channel binding data.
+            expectedChannelBindingPayloadInFinalClientMessage = gs2_header;
+        }
+
+        nonce = clientNonce + UUID.randomUUID().toString();
+
+        serverFirstMessage = String.format("r=%s,s=%s,i=%d", nonce, DatatypeConverter.printBase64Binary(getOrFakeSalt(username)),
+            getIterations(username));
+        return serverFirstMessage.getBytes(StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Generate the final response that the server returns to the client, includes the server signature.
+     *
+     * @param response the client final message
+     */
+    private byte[] generateServerFinalMessage(final byte[] response) throws SaslException
+    {
+        final String clientFinalMessage = new String(response, StandardCharsets.UTF_8);
+        final Matcher m = CLIENT_FINAL_MESSAGE.matcher(clientFinalMessage);
+        if (!m.matches()) {
+            throw new SaslException("Invalid client final message");
+        }
+
+        // client-final-message regex: (c=([^,]*),r=([^,]*)),p=(.*)$")
+        final String clientFinalMessageWithoutProof = m.group(1); // (c=([^,]*),r=([^,]*))
+        final String channelBinding = m.group(2);                 // c=([^,]*)
+        final String clientNonce = m.group(3);                    // r=([^,]*)
+        final String proof = m.group(4);                          // p=(.*)
+
+        if (proof == null || proof.isEmpty()) {
+            throw new SaslException("Invalid client final message: missing proof attribute");
+        }
+
+        if (channelBinding == null || channelBinding.isEmpty()) {
+            throw new SaslException("Invalid client final message: missing channel binding attribute");
+        }
+
+        if (clientNonce == null || clientNonce.isEmpty()) {
+            throw new SaslException("Invalid client final message: missing nonce attribute");
+        }
+
+        // Verify nonce: RFC 5802 §5: must equal client_nonce (from initial client response) + server_nonce (from initial server response)
+        if (!nonce.equals(clientNonce)) { // Constant-time operation is important for keys, not for public protocol values like nonces.
+            // Possible replay or tampering
+            throw new SaslException("Invalid client final message: incorrect nonce attribute value");
+        }
+
+        // Verify channel binding payload.
+        final byte[] decodedChannelBinding = DatatypeConverter.parseBase64Binary(channelBinding);
+        if (!Arrays.equals(expectedChannelBindingPayloadInFinalClientMessage, decodedChannelBinding)) { // Constant-time comparison is not needed here: channel binding payloads are not secrets, timing leakage is not meaningful.
+            throw new SaslException("Invalid client final message: channel binding payload does not match expected payload");
+        }
+
+        try {
+            String authMessage = clientFirstMessageBare + "," + serverFirstMessage + "," + clientFinalMessageWithoutProof;
+            byte[] storedKey = getOrFakeStoredKey(username);
+            byte[] serverKey = getOrFakeServerKey(username);
+
+            byte[] clientSignature = computeHmac(storedKey, authMessage);
+            byte[] serverSignature = computeHmac(serverKey, authMessage);
+
+            byte[] clientKey = clientSignature.clone();
+            byte[] decodedProof = DatatypeConverter.parseBase64Binary(proof);
+            if (decodedProof.length != clientKey.length) {
+                throw new SaslException("Invalid proof length: expected " + clientKey.length + " bytes, got " + decodedProof.length);
+            }
+            for (int i = 0; i < clientKey.length; i++) {
+                clientKey[i] ^= decodedProof[i];
+            }
+
+            if (!MessageDigest.isEqual(storedKey, digest(clientKey))) {
+                throw new SaslException("Authentication failed for: '" + username + "'");
+            }
+            return ("v=" + DatatypeConverter.printBase64Binary(serverSignature))
+                .getBytes(StandardCharsets.UTF_8);
+        } catch (NoSuchAlgorithmException e) {
+            throw new SaslException(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Determines whether the authentication exchange has completed.
+     *
+     * This method is typically called after each invocation of {@code evaluateResponse()} to determine whether the
+     * authentication has completed successfully or should be continued.
+     *
+     * @return true if the authentication exchange has completed; false otherwise.
+     */
+    @Override
+    public boolean isComplete()
+    {
+        return state == State.COMPLETE;
+    }
+
+    /**
+     * Unwraps a byte array received from the client. SCRAM supports no security layer.
+     *
+     * @throws SaslException if attempted to use this method.
+     */
+    @Override
+    public byte[] unwrap(byte[] incoming, int offset, int len) throws SaslException
+    {
+        if (isComplete()) {
+            throw new IllegalStateException("SCRAM does not support integrity or privacy");
+        } else {
+            throw new IllegalStateException("SCRAM authentication not completed");
+        }
+    }
+
+    /**
+     * Wraps a byte array to be sent to the client. SCRAM supports no security layer.
+     *
+     * @throws SaslException if attempted to use this method.
+     */
+    @Override
+    public byte[] wrap(byte[] outgoing, int offset, int len) throws SaslException
+    {
+        if (isComplete()) {
+            throw new IllegalStateException("SCRAM does not support integrity or privacy");
+        } else {
+            throw new IllegalStateException("SCRAM authentication not completed");
+        }
+    }
+
+    /**
+     * Reports the authorization ID in effect for the client of this session.
+     *
+     * This method can only be called if isComplete() returns true.
+     *
+     * @return The authorization ID of the client.
+     * @exception IllegalStateException if this authentication session has not completed
+     */
+    @Override
+    public String getAuthorizationID()
+    {
+        if (isComplete()) {
+            return username;
+        } else {
+            throw new IllegalStateException("SCRAM authentication not completed");
+        }
+    }
+
+    /**
+     * Retrieves a negotiated property applicable to this SCRAM authentication exchange.
+     *
+     * SCRAM mechanisms negotiate only authentication quality-of-protection ({@code auth}). SCRAM -PLUS mechanisms also
+     * expose the negotiated channel binding type.
+     *
+     * @param propName the property name
+     * @return the negotiated property value, or {@code null} if the property is not applicable
+     * @throws IllegalStateException if the authentication exchange has not completed
+     */
+    @Override
+    public Object getNegotiatedProperty(String propName) {
+        if (isComplete()) {
+            if (Sasl.QOP.equals(propName)) {
+                return "auth";
+            } else if (isPlusMechanism && PROPNAME_CHANNELBINDINGTYPE.equals(propName)) {
+                return gs2CbindName;
+            } else {
+                return null;
+            }
+        } else {
+            throw new IllegalStateException("SCRAM authentication not completed");
+        }
+    }
+
+    /**
+     * Disposes of any system resources or security-sensitive information the SaslServer might be using.
+     *
+     * Invoking this method invalidates the SaslServer instance. This method is idempotent.
+     *
+     * @throws SaslException If a problem was encountered while disposing the resources.
+     */
+    @Override
+    public void dispose() throws SaslException
+    {
+        username = null;
+        nonce = null;
+        serverFirstMessage = null;
+        clientFirstMessageBare = null;
+        if (expectedChannelBindingPayloadInFinalClientMessage != null) {
+            Arrays.fill(expectedChannelBindingPayloadInFinalClientMessage, (byte) 0);
+            expectedChannelBindingPayloadInFinalClientMessage = null;
+        }
+        state = State.INITIAL;
+        gs2CbindName = null;
+    }
 
     /**
      * Extracts the raw GS2 header from a SCRAM client-first-message byte array.
@@ -67,7 +723,7 @@ public abstract class ScramSaslServer implements SaslServer
      * {@code 0} up to and including the second comma (i.e., the full GS2 header including its trailing comma).
      *
      * No character decoding or normalization is performed. This ensures that the returned GS2 header is byte-for-
-     * byte identical to the original input, which is required for correct SCRAM-SHA-1-PLUS channel binding validation.
+     * byte identical to the original input, which is required for correct SCRAM channel binding validation.
      *
      * @param data the raw SCRAM client-first-message bytes
      * @return a byte array containing the complete GS2 header including the trailing comma

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServer.java
@@ -16,23 +16,15 @@
 
 package org.jivesoftware.openfire.sasl;
 
-import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
-import java.util.Arrays;
+import java.util.Base64;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import javax.annotation.Nonnull;
-import javax.security.sasl.Sasl;
+import javax.annotation.Nullable;
 import javax.security.sasl.SaslException;
-import javax.security.sasl.SaslServer;
-import javax.xml.bind.DatatypeConverter;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.jivesoftware.openfire.auth.AuthFactory;
@@ -40,8 +32,6 @@ import org.jivesoftware.openfire.auth.ConnectionException;
 import org.jivesoftware.openfire.auth.DefaultAuthProvider;
 import org.jivesoftware.openfire.auth.InternalUnauthenticatedException;
 import org.jivesoftware.openfire.auth.ScramUtils;
-import org.jivesoftware.openfire.net.SASLAuthentication;
-import org.jivesoftware.openfire.session.LocalSession;
 import org.jivesoftware.openfire.user.UserNotFoundException;
 import org.jivesoftware.util.StringUtils;
 import org.jivesoftware.util.SystemProperty;
@@ -56,11 +46,13 @@ import org.slf4j.LoggerFactory;
  */
 public class ScramSha1SaslServer extends ScramSaslServer {
 
+    private static final Logger Log = LoggerFactory.getLogger(ScramSha1SaslServer.class);
+
     /**
      * Stores a server-side secret used when handling authentication attempts for non-existing users in SCRAM-SHA-1 (-PLUS).
      *
-     * Prefer to use #getInitializedServerSecretForNonExistentUsers() instead of accessing this property directly, as
-     * the method will make sure that the one-time initialization that's required for usage will occur.
+     * Prefer to use {@link #getServerSecretForNonExistentUsers()} instead of accessing this property directly, as
+     * the method will make sure that the one-time initialization required for usage will occur.
      *
      * @see #getServerSecretForNonExistentUsers()
      */
@@ -71,11 +63,41 @@ public class ScramSha1SaslServer extends ScramSaslServer {
         .setDynamic(Boolean.TRUE)
         .build();
 
+    public static final SystemProperty<Integer> ITERATION_COUNT = SystemProperty.Builder.ofType(Integer.class)
+        .setKey("sasl.scram-sha-1.iteration-count")
+        .setDefaultValue(ScramUtils.DEFAULT_ITERATION_COUNT)
+        .setDynamic(Boolean.TRUE)
+        .build();
+
+    public ScramSha1SaslServer(final boolean isPlusMechanism, final Map<String, ?> props)
+    {
+        super(isPlusMechanism, props);
+    }
+
+    /**
+     * Constructor for testing purposes.
+     */
+    @VisibleForTesting
+    ScramSha1SaslServer(final boolean isPlusMechanism, final Map<String, ?> props, final ChannelBindingProviderManager channelBindingProviderManager, final Set<String> serverSupportedSaslMechanismNames)
+    {
+        super(isPlusMechanism, props, channelBindingProviderManager, serverSupportedSaslMechanismNames);
+    }
+
+    /**
+     * Returns the IANA-registered mechanism name of this SASL server.
+     * ("SCRAM-SHA-1").
+     * @return A non-null string representing the IANA-registered mechanism name.
+     */
+    @Override
+    public String getMechanismName() {
+        return isPlusMechanism ? "SCRAM-SHA-1-PLUS" : "SCRAM-SHA-1";
+    }
+
     /**
      * Retrieves a server-side secret used when handling authentication attempts for non-existing users in
      * SCRAM-SHA-1 (-PLUS).
      *
-     * This method ensures that the one-time initialization that is required for usage will occur.
+     * This method ensures that the one-time initialization required for usage will occur.
      *
      * Instead of failing immediately, the server derives deterministic, fake SCRAM credentials (such as stored keys,
      * server keys, and where applicable salt values) based on this secret. This ensures that authentication processing
@@ -90,7 +112,8 @@ public class ScramSha1SaslServer extends ScramSaslServer {
      *
      * @see <a href="https://igniterealtime.atlassian.net/browse/OF-3258">OF-3258: Guard against user enumeration in ScramSha1SaslServer</a>
      */
-    public synchronized static String getServerSecretForNonExistentUsers()
+    @Override
+    public synchronized String getServerSecretForNonExistentUsers()
     {
         // OF-3258: Ensure a consistent but unpredictable server secret is available.
         final String serverSecret = SERVER_SECRET_NONEXISTENT_USERS.getValue();
@@ -100,412 +123,32 @@ public class ScramSha1SaslServer extends ScramSaslServer {
         return SERVER_SECRET_NONEXISTENT_USERS.getValue();
     }
 
-    public static final String PROPNAME_CHANNELBINDINGTYPE = "channelbindingtype";
-
-    public static final SystemProperty<Integer> ITERATION_COUNT = SystemProperty.Builder.ofType(Integer.class)
-        .setKey("sasl.scram-sha-1.iteration-count")
-        .setDefaultValue(ScramUtils.DEFAULT_ITERATION_COUNT)
-        .setDynamic(Boolean.TRUE)
-        .build();
-    private static final Logger Log = LoggerFactory.getLogger(ScramSha1SaslServer.class);
-    private static final Pattern
-            CLIENT_FIRST_MESSAGE = Pattern.compile("^(([pny])=?([^,]*),([^,]*),)(m?=?[^,]*,?n=([^,]*),r=([^,]*),?.*)$"),
-            CLIENT_FINAL_MESSAGE = Pattern.compile("(c=([^,]*),r=([^,]*)),p=(.*)$");
-
-    private final ChannelBindingProviderManager channelBindingProviderManager;
-    private final Set<String> serverSupportedSaslMechanismNames;
-
-    private final boolean isPlusMechanism;
-    private final Map<String, ?> props;
-    private String username;
-    private State state = State.INITIAL;
-    private String nonce;
-    private String serverFirstMessage;
-    private String clientFirstMessageBare;
-    private final SecureRandom random = new SecureRandom();
-    private byte[] expectedChannelBindingPayloadInFinalClientMessage;
-    private String gs2CbindName;
-
-    private enum State {
-        INITIAL,
-        IN_PROGRESS,
-        COMPLETE;
-    }
-
-    public ScramSha1SaslServer(final boolean isPlusMechanism, final Map<String, ?> props)
-    {
-        this.isPlusMechanism = isPlusMechanism;
-        this.props = props;
-        this.channelBindingProviderManager = ChannelBindingProviderManager.getInstance();
-        this.serverSupportedSaslMechanismNames = SASLAuthentication.getSupportedMechanisms();
-    }
-
     /**
-     * Constructor for testing purposes.
-     */
-    @VisibleForTesting
-    ScramSha1SaslServer(final boolean isPlusMechanism, final Map<String, ?> props, final ChannelBindingProviderManager channelBindingProviderManager, final Set<String> serverSupportedSaslMechanismNames)
-    {
-        this.isPlusMechanism = isPlusMechanism;
-        this.props = props;
-        this.channelBindingProviderManager = channelBindingProviderManager;
-        this.serverSupportedSaslMechanismNames = serverSupportedSaslMechanismNames;
-    }
-
-    /**
-     * Returns the IANA-registered mechanism name of this SASL server.
-     * ("SCRAM-SHA-1").
-     * @return A non-null string representing the IANA-registered mechanism name.
-     */
-    @Override
-    public String getMechanismName() {
-        return isPlusMechanism ? "SCRAM-SHA-1-PLUS" : "SCRAM-SHA-1";
-    }
-
-    /**
-     * Evaluates the response data and generates a challenge.
-     *
-     * If a response is received from the client during the authentication
-     * process, this method is called to prepare an appropriate next
-     * challenge to submit to the client. The challenge is null if the
-     * authentication has succeeded and no more challenge data is to be sent
-     * to the client. It is non-null if the authentication must be continued
-     * by sending a challenge to the client, or if the authentication has
-     * succeeded but challenge data needs to be processed by the client.
-     * {@code isComplete()} should be called
-     * after each call to {@code evaluateResponse()},to determine if any further
-     * response is needed from the client.
-     *
-     * @param response The non-null (but possibly empty) response sent
-     * by the client.
-     *
-     * @return The possibly null challenge to send to the client.
-     * It is null if the authentication has succeeded and there is
-     * no more challenge data to be sent to the client.
-     * @exception SaslException If an error occurred while processing
-     * the response or generating a challenge.
-     */
-    @Override
-    public byte[] evaluateResponse(final byte[] response) throws SaslException {
-        try {
-            byte[] challenge;
-            switch (state)
-            {
-                case INITIAL:
-                    challenge = generateServerFirstMessage(response);
-                    state = State.IN_PROGRESS;
-                    break;
-                case IN_PROGRESS:
-                    challenge = generateServerFinalMessage(response);
-                    state = State.COMPLETE;
-                    break;
-                case COMPLETE:
-                    if (response == null || response.length == 0)
-                    {
-                        challenge = new byte[0];
-                        break;
-                    }
-                    throw new SaslException("Unexpected response after authentication completed");
-                default:
-                    throw new SaslException("No response expected in state " + state);
-
-            }
-            return challenge;
-        } catch (RuntimeException ex) {
-           throw new SaslException("Unexpected exception while evaluating SASL response.", ex);
-        }
-    }
-
-    /**
-     * First response returns:
-     *   - the nonce (client nonce appended with our own random UUID)
-     *   - the salt
-     *   - the number of iterations
-     */
-    private byte[] generateServerFirstMessage(final byte[] response) throws SaslException {
-        String clientFirstMessage = new String(response, StandardCharsets.UTF_8);
-        Matcher m = CLIENT_FIRST_MESSAGE.matcher(clientFirstMessage);
-        if (!m.matches()) {
-            throw new SaslException("Invalid first client message");
-        }
-        final byte[] gs2_header = extractRawGS2Header(response); // Using raw header to prevent any normalization issues that might pop up when using something like: gs2Header.getBytes(StandardCharsets.UTF_8);
-//        String gs2Header = m.group(1);
-        String gs2CbindFlag = m.group(2);
-        gs2CbindName = m.group(3);
-//        String authzId = m.group(4);
-        clientFirstMessageBare = m.group(5);
-        username = m.group(6);
-        String clientNonce = m.group(7);
-
-        if (username == null || username.isEmpty()) {
-            throw new SaslException("Invalid first client message: Username cannot be empty");
-        }
-        if (clientNonce == null || clientNonce.isEmpty()) {
-            throw new SaslException("Invalid first client message: Client nonce cannot be empty");
-        }
-
-        // https://www.rfc-editor.org/rfc/rfc5802.html#section-6: If the flag is set to "y" and the server supports
-        // channel binding, the server MUST fail authentication. This is because if the client sets the channel binding
-        // flag to "y", then the client must have believed that the server did not support channel binding -- if the
-        // server did in fact support channel binding, then this is an indication that there has been a downgrade attack
-        // (e.g., an attacker changed the server's mechanism list to exclude the -PLUS suffixed SCRAM mechanism name(s)).
-        final boolean clientSupportsChannelBindingButThinksServerDoesNot = "y".equals(gs2CbindFlag);
-        final boolean serverSupportsChannelBinding = serverSupportedSaslMechanismNames.stream().anyMatch(mechanism -> mechanism.endsWith("-PLUS"));
-        if (clientSupportsChannelBindingButThinksServerDoesNot && serverSupportsChannelBinding) {
-            throw new SaslException("Client supports channel binding, but thinks the server does not (while it does). Rejecting authentication to prevent downgrade attack.");
-        }
-
-        final boolean clientRequiresChannelBinding = "p".equals(gs2CbindFlag);
-        if (clientRequiresChannelBinding && !isPlusMechanism) {
-            throw new SaslException("Client requires channel binding, but is not using a -PLUS mechanism. Rejecting authentication.");
-        }
-
-        if (isPlusMechanism)
-        {
-            if (!clientRequiresChannelBinding) {
-                throw new SaslException("Channel binding required for -PLUS. Rejecting authentication.");
-            }
-
-            if (!serverSupportsChannelBinding) {
-                throw new SaslException("Client requires channel binding, but server does not support channel binding. Rejecting authentication.");
-            }
-
-            // https://www.rfc-editor.org/rfc/rfc5802.html#section-6: If the channel binding flag was "p" and the server
-            // does not support the indicated channel binding type, then the server MUST fail authentication.
-            if (gs2CbindName == null || gs2CbindName.isEmpty() || !channelBindingProviderManager.supportsChannelBinding(gs2CbindName)) {
-                throw new SaslException("Client requires channel binding, but server does not support the indicated channel binding type '" + gs2CbindName + "'. Rejecting authentication.");
-            }
-
-            // Prepare channel binding data.
-            final LocalSession session = (LocalSession) props.get(LocalSession.class.getCanonicalName());
-            if (session == null || session.getConnection() == null) {
-                throw new SaslException("Local session not found in properties. Rejecting authentication.");
-            }
-            final Optional<byte[]> channelBindingData = session.getConnection().getChannelBindingData(gs2CbindName);
-            if (channelBindingData.isEmpty()) {
-                Log.debug("Unable to retrieve channel binding data for '{}'. Rejecting authentication.", gs2CbindName);
-                throw new SaslException("Unable to retrieve channel binding data for '" + gs2CbindName + "'. Rejecting authentication.");
-            }
-
-            // In the final client message, we expect to find a combination of the gs2 header and channel binding data.
-            final byte[] cb_data = channelBindingData.get();
-            expectedChannelBindingPayloadInFinalClientMessage = new byte[gs2_header.length + cb_data.length];
-            System.arraycopy(gs2_header, 0, expectedChannelBindingPayloadInFinalClientMessage, 0        , gs2_header.length);
-            System.arraycopy(cb_data,    0, expectedChannelBindingPayloadInFinalClientMessage, gs2_header.length, cb_data.length);
-        } else {
-            // If this is _not_ a -PLUS mechanism, we still need to verify the channel binding payload in the final client message.
-            // In that case, it should not have trailing channel binding data.
-            expectedChannelBindingPayloadInFinalClientMessage = gs2_header;
-        }
-
-        nonce = clientNonce + UUID.randomUUID().toString();
-
-        serverFirstMessage = String.format("r=%s,s=%s,i=%d", nonce, DatatypeConverter.printBase64Binary(getOrCreateSalt(username)),
-                getIterations(username));
-        return serverFirstMessage.getBytes(StandardCharsets.UTF_8);
-    }
-
-    /**
-     * Final response returns the server signature.
-     */
-    private byte[] generateServerFinalMessage(final byte[] response) throws SaslException {
-        String clientFinalMessage = new String(response, StandardCharsets.UTF_8);
-        Matcher m = CLIENT_FINAL_MESSAGE.matcher(clientFinalMessage);
-        if (!m.matches()) {
-            throw new SaslException("Invalid client final message");
-        }
-
-        // client-final-message regex: (c=([^,]*),r=([^,]*)),p=(.*)$")
-        final String clientFinalMessageWithoutProof = m.group(1); // (c=([^,]*),r=([^,]*))
-        final String channelBinding = m.group(2);                 // c=([^,]*)
-        final String clientNonce = m.group(3);                    // r=([^,]*)
-        final String proof = m.group(4);                          // p=(.*)
-
-        if (proof == null || proof.isEmpty()) {
-            throw new SaslException("Invalid client final message: missing proof attribute");
-        }
-
-        if (channelBinding == null || channelBinding.isEmpty()) {
-            throw new SaslException("Invalid client final message: missing channel binding attribute");
-        }
-
-        if (clientNonce == null || clientNonce.isEmpty()) {
-            throw new SaslException("Invalid client final message: missing nonce attribute");
-        }
-
-        // Verify nonce: RFC 5802 §5: must equal client_nonce (from initial client response) + server_nonce (from initial server response)
-        if (!nonce.equals(clientNonce)) { // Constant-time operation is important for keys, not for public protocol values like nonces.
-            // Possible replay or tampering
-            throw new SaslException("Invalid client final message: incorrect nonce attribute value");
-        }
-
-        // Verify channel binding payload.
-        final byte[] decodedChannelBinding = DatatypeConverter.parseBase64Binary(channelBinding);
-        if (!Arrays.equals(expectedChannelBindingPayloadInFinalClientMessage, decodedChannelBinding)) {
-            throw new SaslException("Invalid client final message: channel binding payload does not match expected payload");
-        }
-
-        try {
-            String authMessage = clientFirstMessageBare + "," + serverFirstMessage + "," + clientFinalMessageWithoutProof;
-            byte[] storedKey = getOrFakeStoredKey(username);
-            byte[] serverKey = getOrFakeServerKey(username);
-
-            byte[] clientSignature = ScramUtils.computeHmac(storedKey, authMessage);
-            byte[] serverSignature = ScramUtils.computeHmac(serverKey, authMessage);
-            
-            byte[] clientKey = clientSignature.clone();
-            byte[] decodedProof = DatatypeConverter.parseBase64Binary(proof);
-            if (decodedProof.length != clientKey.length) {
-                throw new SaslException("Invalid proof length: expected " + clientKey.length + " bytes, got " + decodedProof.length);
-            }
-            for (int i = 0; i < clientKey.length; i++) {
-                clientKey[i] ^= decodedProof[i];
-            }
-
-            if (!MessageDigest.isEqual(storedKey, MessageDigest.getInstance("SHA-1").digest(clientKey))) {
-                throw new SaslException("Authentication failed for: '"+username+"'");
-            }
-            return ("v=" + DatatypeConverter.printBase64Binary(serverSignature))
-                    .getBytes(StandardCharsets.UTF_8);
-        } catch (NoSuchAlgorithmException e) {
-            throw new SaslException(e.getMessage(), e);
-        }
-    }
-
-    /**
-     * Determines whether the authentication exchange has completed.
-     * This method is typically called after each invocation of
-     * {@code evaluateResponse()} to determine whether the
-     * authentication has completed successfully or should be continued.
-     * @return true if the authentication exchange has completed; false otherwise.
-     */
-    @Override
-    public boolean isComplete() {
-        return state == State.COMPLETE;
-    }
-
-    /**
-     * Reports the authorization ID in effect for the client of this
-     * session.
-     * This method can only be called if isComplete() returns true.
-     * @return The authorization ID of the client.
-     * @exception IllegalStateException if this authentication session has not completed
-     */
-    @Override
-    public String getAuthorizationID() {
-        if (isComplete()) {
-            return username;
-        } else {
-            throw new IllegalStateException("SCRAM-SHA-1 authentication not completed");
-        }
-    }
-
-    /**
-     * Unwraps a byte array received from the client. SCRAM-SHA-1 supports no security layer.
-     * 
-     * @throws SaslException if attempted to use this method.
-     */
-    @Override
-    public byte[] unwrap(byte[] incoming, int offset, int len)
-        throws SaslException {
-        if (isComplete()) {
-            throw new IllegalStateException("SCRAM-SHA-1 does not support integrity or privacy");
-        } else {
-            throw new IllegalStateException("SCRAM-SHA-1 authentication not completed");
-        }
-    }
-
-    /**
-     * Wraps a byte array to be sent to the client. SCRAM-SHA-1 supports no security layer.
-     *
-     * @throws SaslException if attempted to use this method.
-     */
-    @Override
-    public byte[] wrap(byte[] outgoing, int offset, int len)
-        throws SaslException {
-        if (isComplete()) {
-            throw new IllegalStateException("SCRAM-SHA-1 does not support integrity or privacy");
-        } else {
-            throw new IllegalStateException("SCRAM-SHA-1 authentication not completed");
-        }
-    }
-
-    /**
-     * Retrieves the negotiated property.
-     * This method can be called only after the authentication exchange has
-     * completed (i.e., when {@code isComplete()} returns true); otherwise, an
-     * {@code IllegalStateException} is thrown.
-     *
-     * @param propName the property
-     * @return The value of the negotiated property. If null, the property was
-     * not negotiated or is not applicable to this mechanism.
-     * @exception IllegalStateException if this authentication exchange has not completed
-     */
-    @Override
-    public Object getNegotiatedProperty(String propName) {
-        if (isComplete()) {
-            if (propName.equals(Sasl.QOP)) {
-                return "auth";
-            } else if (isPlusMechanism && propName.equals(PROPNAME_CHANNELBINDINGTYPE)) {
-                return gs2CbindName;
-            } else {
-                return null;
-            }
-        } else {
-            throw new IllegalStateException("SCRAM-SHA-1 authentication not completed");
-        }
-    }
-
-     /**
-      * Disposes of any system resources or security-sensitive information
-      * the SaslServer might be using. Invoking this method invalidates
-      * the SaslServer instance. This method is idempotent.
-      * @throws SaslException If a problem was encountered while disposing
-      * the resources.
-      */
-    @Override
-    public void dispose() throws SaslException {
-        username = null;
-        nonce = null;
-        serverFirstMessage = null;
-        clientFirstMessageBare = null;
-        expectedChannelBindingPayloadInFinalClientMessage = null;
-        gs2CbindName = null;
-        state = State.INITIAL;
-    }
-
-    /**
-     * Retrieve the salt for a given username.
+     * Retrieve the salt from the database for a given username.
      *
      * When a salt does not currently exist for an existing user, but a password is set, that value is used to create
      * and persist a new salt for that user.
      *
-     * Returns a username-specific salt if the user doesn't exist to mimic an invalid password. This also guards against
-     * user enumeration attacks.
-     *
-     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-3258">OF-3258: Guard against user enumeration in ScramSha1SaslServer</a>
+     * @param username the username for which the salt is to be retrieved
+     * @return the salt
+     * @throws UserNotFoundException if the user is not found
      */
     @Override
-    protected byte[] getOrCreateSalt(final String username)
+    protected byte[] getSalt(final String username) throws UserNotFoundException
     {
-        try
-        {
-            final String saltBase64 = AuthFactory.getSalt(username);
-            if (saltBase64 == null) {
+        final String saltBase64 = AuthFactory.getSalt(username);
+        if (saltBase64 == null) {
+            try
+            {
                 return handleMissingSalt(username);
             }
-
-            return decodeSalt(saltBase64);
+            catch (UnsupportedOperationException | ConnectionException | InternalUnauthenticatedException e)
+            {
+                Log.debug("Exception when handling missing salt for user '{}'", username, e);
+                return null;
+            }
         }
-        catch (UserNotFoundException e)
-        {
-            Log.debug("User '{}' not found. Returning fake salt.", username, e);
-            return generateFakeSalt(username);
-        }
-        catch (UnsupportedOperationException | ConnectionException | InternalUnauthenticatedException e) {
-            Log.warn("Exception in SCRAM.getSalt() for user '{}'", username, e);
-            return generateFakeSalt(username);
-        }
+        return decodeSalt(saltBase64, username);
     }
 
     /**
@@ -519,6 +162,7 @@ public class ScramSha1SaslServer extends ScramSaslServer {
      * @throws ConnectionException when there's an issue with connecting to the user-provider
      * @throws UnsupportedOperationException when a plain-text password cannot be retrieved for this user.
      */
+    @Nullable
     private byte[] handleMissingSalt(String username) throws UserNotFoundException, InternalUnauthenticatedException, ConnectionException, UnsupportedOperationException
     {
         Log.debug("No salt found for '{}', regenerating.", username);
@@ -535,70 +179,44 @@ public class ScramSha1SaslServer extends ScramSaslServer {
         final String newSalt = AuthFactory.getSalt(username);
         if (newSalt == null) {
             Log.debug("Salt regeneration failed for '{}'", username);
-            return generateFakeSalt(username);
+            return null;
         }
-        return decodeSalt(newSalt);
+        return decodeSalt(newSalt, username);
     }
 
     /**
      * Decode a base64-encoded salt.
      *
      * @param base64Salt The base64-encoded salt to decode
+     * @param username The username for which the salt is being decoded
      * @return The decoded salt as a byte array
      */
-    private byte[] decodeSalt(@Nonnull final String base64Salt)
+    private byte[] decodeSalt(@Nonnull final String base64Salt, @Nonnull final String username)
     {
-        return DatatypeConverter.parseBase64Binary(base64Salt);
+        try {
+            return Base64.getDecoder().decode(base64Salt);
+        } catch (IllegalArgumentException e) {
+            Log.warn("Stored salt for user '{}' contains invalid base64.", username, e);
+            return null;
+        }
+    }
+
+    @Override
+    protected int getSaltLength()
+    {
+        return DefaultAuthProvider.SALT_LENGTH;
     }
 
     /**
-     * Generate a fake salt to guard against user enumeration attacks (see OF-3258).
+     * Retrieve the iteration count for a given username.
      *
-     * The returned salt is a deterministic but cryptographically unpredictable value derived from the username and a
-     * server-side secret. The returned value is always exactly {@link DefaultAuthProvider#SALT_LENGTH} bytes long.
+     * This method can return a default value if a user-specific iteration count is not available.
      *
-     * @param username The username for which to generate a fake salt
-     * @return a fake salt of length {@link DefaultAuthProvider#SALT_LENGTH}.
-     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-3258">OF-3258: Guard against user enumeration in ScramSha1SaslServer</a>
+     * @param username the username for which the iteration count is to be retrieved
+     * @return the iteration count
      */
-    private byte[] generateFakeSalt(String username)
-    {
-        final int length = DefaultAuthProvider.SALT_LENGTH;
-
-        try
-        {
-            final byte[] key = getServerSecretForNonExistentUsers().getBytes(StandardCharsets.UTF_8);
-            final byte[] result = new byte[length];
-
-            int offset = 0;
-            int counter = 0;
-
-            while (offset < length)
-            {
-                // Domain separation + counter to expand output deterministically
-                final byte[] block = ScramUtils.computeHmac(key, "fake-salt-for-" + username + ":" + counter);
-                final int toCopy = Math.min(block.length, length - offset);
-                System.arraycopy(block, 0, result, offset, toCopy);
-
-                offset += toCopy;
-                counter++;
-            }
-
-            return result;
-        }
-        catch (SaslException e)
-        {
-            // Give up trying to be deterministic. Return a random salt.
-            final byte[] salt = new byte[length];
-            random.nextBytes(salt);
-            return salt;
-        }
-    }
-    
-    /**
-     * Retrieve the iteration count from the database for a given username.
-     */
-    private int getIterations(final String username) {
+    @Override
+    protected int getIterations(final String username) {
         try {
             return AuthFactory.getIterations(username);
         } catch (UserNotFoundException e) {
@@ -607,88 +225,88 @@ public class ScramSha1SaslServer extends ScramSaslServer {
     }
 
     /**
-     * Retrieve the server key from the database for a given username, but returns a fake key if none is found.
+     * Retrieve the server key from the database for a given username.
      *
-     * Returning a fake key helps guard against timing attacks: instead of short-circuiting the operation,
-     * a fake key is generated to ensure consistent response times and prevent potential timing attacks.
-     *
-     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-3257">OF-3257: Guard against timing attacks in ScramSha1SaslServer</a>
+     * @param username the username for which the server key is to be retrieved
+     * @return the server key as a byte array, or null if the key is not found
+     * @throws UserNotFoundException if the user is not found
      */
     @Override
-    protected byte[] getOrFakeServerKey(String username) {
-        try {
-            byte[] key = getServerKey(username);
-            if (key != null) {
-                return key;
-            }
-        } catch (UserNotFoundException ignored) {
-            // fall through
-        }
-        return generateFakeKey("server-key-" + username);
-    }
-
-    /**
-     * Retrieve the server key from the database for a given username.
-     */
-    private byte[] getServerKey(final String username) throws UserNotFoundException {
+    protected byte[] getServerKey(final String username) throws UserNotFoundException
+    {
         final String serverKey = AuthFactory.getServerKey(username);
         if (serverKey == null) {
             return null;
         } else {
-            return DatatypeConverter.parseBase64Binary( serverKey );
-        }
-    }
-
-    /**
-     * Retrieve the stored key from the database for a given username, but returns a fake key if none is found.
-     *
-     * Returning a fake key helps guard against timing attacks: instead of short-circuiting the operation,
-     * a fake key is generated to ensure consistent response times and prevent potential timing attacks.
-     *
-     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-3257">OF-3257: Guard against timing attacks in ScramSha1SaslServer</a>
-     */
-    @Override
-    protected byte[] getOrFakeStoredKey(final String username) {
-        try {
-            byte[] key = getStoredKey(username);
-            if (key != null) {
-                return key;
+            try {
+                return Base64.getDecoder().decode(serverKey);
+            } catch (IllegalArgumentException e) {
+                Log.warn("Stored server key for user '{}' contains invalid base64.", username, e);
+                return null;
             }
-        } catch (UserNotFoundException ignored) {
-            // fall through
         }
-        return generateFakeKey("stored-key-" + username);
     }
 
     /**
      * Retrieve the stored key from the database for a given username.
+     *
+     * @param username the username for which the stored key is to be retrieved
+     * @return the stored key as a byte array, or null if the key is not found
+     * @throws UserNotFoundException if the user is not found
      */
-    private byte[] getStoredKey(final String username) throws UserNotFoundException {
+    @Override
+    protected byte[] getStoredKey(final String username) throws UserNotFoundException
+    {
         final String storedKey = AuthFactory.getStoredKey(username);
         if (storedKey == null) {
             return null;
         } else {
-            return DatatypeConverter.parseBase64Binary( storedKey );
+            try {
+                return Base64.getDecoder().decode(storedKey);
+            } catch (IllegalArgumentException e) {
+                Log.warn("Stored key for user '{}' contains invalid base64.", username, e);
+                return null;
+            }
         }
     }
 
     /**
-     * Generate a fake key to guard against timing attacks (see OF-3257).
+     * Computes the SHA-1 digest of the provided value.
      *
-     * @param input a string input for which to generate a fake key
-     * @return a fake key
+     * @param value the input value to digest
+     * @return the SHA-1 digest
+     * @throws NoSuchAlgorithmException if SHA-1 is unavailable
      */
-    private byte[] generateFakeKey(String input)
+    @Override
+    protected byte[] digest(final byte[] value) throws NoSuchAlgorithmException
     {
-        try {
-            return ScramUtils.computeHmac(
-                getServerSecretForNonExistentUsers().getBytes(StandardCharsets.UTF_8),
-                input
-            );
-        } catch (SaslException e) {
-            byte[] fallback = new byte[24];
-            random.nextBytes(fallback);
-            return fallback;
-        }
+        return MessageDigest.getInstance("SHA-1").digest(value);
+    }
+
+    /**
+     * Computes an HMAC-SHA1 value for the supplied key and input string.
+     *
+     * @param key the HMAC key
+     * @param value the input value
+     * @return the computed HMAC-SHA1 output
+     * @throws SaslException if the HMAC computation fails
+     */
+    @Override
+    protected byte[] computeHmac(byte[] key, String value) throws SaslException
+    {
+        return ScramUtils.computeHmac(key, value);
+    }
+
+    /**
+     * Returns the length, in bytes, of SHA-1-derived SCRAM keys.
+     *
+     * SCRAM-SHA-1 uses 160-bit derived keys.
+     *
+     * @return the SHA-1 derived key length in bytes
+     */
+    @Override
+    protected int getDerivedKeyLengthBytes()
+    {
+        return 20;
     }
 }

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/sasl/AbstractScramCredentialObfuscationTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/sasl/AbstractScramCredentialObfuscationTest.java
@@ -216,8 +216,8 @@ public abstract class AbstractScramCredentialObfuscationTest
         final ScramSaslServer server = newServer();
 
         // Execute system under test
-        final byte[] salt1 = server.getOrCreateSalt(NON_EXISTENT_USER);
-        final byte[] salt2 = server.getOrCreateSalt(NON_EXISTENT_USER);
+        final byte[] salt1 = server.getOrFakeSalt(NON_EXISTENT_USER);
+        final byte[] salt2 = server.getOrFakeSalt(NON_EXISTENT_USER);
 
         // Verify result
         assertArrayEquals(salt1, salt2, "Fake salt for non-existent user should be deterministic");
@@ -233,8 +233,8 @@ public abstract class AbstractScramCredentialObfuscationTest
         final ScramSaslServer server = newServer();
 
         // Execute system under test
-        final byte[] fakeSalt = server.getOrCreateSalt(NON_EXISTENT_USER);
-        final byte[] realSalt = server.getOrCreateSalt(EXISTENT_USER);
+        final byte[] fakeSalt = server.getOrFakeSalt(NON_EXISTENT_USER);
+        final byte[] realSalt = server.getOrFakeSalt(EXISTENT_USER);
 
         // Verify result
         assertArrayNotEquals(fakeSalt, realSalt, "Fake salt for non-existent user should not match real user salt");
@@ -251,9 +251,9 @@ public abstract class AbstractScramCredentialObfuscationTest
 
         // Execute system under test
         serverSecretProperty().setValue(SERVER_SECRET_1);
-        final byte[] salt1 = server.getOrCreateSalt(NON_EXISTENT_USER);
+        final byte[] salt1 = server.getOrFakeSalt(NON_EXISTENT_USER);
         serverSecretProperty().setValue(SERVER_SECRET_2);
-        final byte[] salt2 = server.getOrCreateSalt(NON_EXISTENT_USER);
+        final byte[] salt2 = server.getOrFakeSalt(NON_EXISTENT_USER);
 
         // Verify result
         assertArrayNotEquals(salt1, salt2, "Fake salt should change when server secret changes");
@@ -269,8 +269,8 @@ public abstract class AbstractScramCredentialObfuscationTest
         final ScramSaslServer server = newServer();
 
         // Execute system under test
-        final byte[] salt1 = server.getOrCreateSalt(EXISTENT_USER);
-        final byte[] salt2 = server.getOrCreateSalt(EXISTENT_USER);
+        final byte[] salt1 = server.getOrFakeSalt(EXISTENT_USER);
+        final byte[] salt2 = server.getOrFakeSalt(EXISTENT_USER);
 
         // Verify result
         assertArrayEquals(salt1, salt2, "Salt for real user should be consistent");


### PR DESCRIPTION
Extract common SCRAM protocol handling logic from the SCRAM-SHA-1 implementation into a new abstract ScramSaslServer base class.

This refactoring centralizes:
- SCRAM state handling and message flow
- GS2 header parsing
- channel binding validation
- downgrade attack protection
- nonce generation and verification
- client/server proof verification
- fake credential generation for timing attack mitigation
- fake salt generation for user enumeration protection
- SASL lifecycle handling

Mechanism-specific implementations now provide only:
- hashing/HMAC primitives
- credential retrieval
- iteration/salt configuration
- algorithm-specific parameters

This significantly reduces duplication between SCRAM variants and establishes a reusable foundation for additional SCRAM mechanisms such as SCRAM-SHA-256 and SCRAM-SHA-256-PLUS.